### PR TITLE
Observability: ship logs to Loki + response-time learning signals

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,7 @@
         "@opentelemetry/exporter-logs-otlp-http": "^0.55.0",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.55.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.55.0",
+        "@opentelemetry/resources": "^1.30.1",
         "@opentelemetry/sdk-logs": "^0.55.0",
         "@opentelemetry/sdk-metrics": "^1.28.0",
         "@opentelemetry/sdk-node": "^0.55.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,7 @@
     "@opentelemetry/exporter-logs-otlp-http": "^0.55.0",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.55.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.55.0",
+    "@opentelemetry/resources": "^1.30.1",
     "@opentelemetry/sdk-logs": "^0.55.0",
     "@opentelemetry/sdk-metrics": "^1.28.0",
     "@opentelemetry/sdk-node": "^0.55.0",

--- a/backend/src/instrumentation.js
+++ b/backend/src/instrumentation.js
@@ -29,19 +29,66 @@ import {
   BatchLogRecordProcessor,
 } from "@opentelemetry/sdk-logs";
 import { logs } from "@opentelemetry/api-logs";
+import { Resource } from "@opentelemetry/resources";
 
 const endpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
 
 if (endpoint && endpoint.trim().length > 0) {
-  // Logs → Loki (Grafana Cloud). Set up BEFORE NodeSDK so the global logger
-  // provider is in place when any winston/pino instrumentation attaches.
-  // @opentelemetry/sdk-logs >=0.200 expects processors via constructor (em vez
-  // do addLogRecordProcessor que existia até 0.55). npm install resolveu >=0.215
-  // via peer dep chain do sdk-node/auto-instrumentations.
+  const serviceName = process.env.OTEL_SERVICE_NAME ?? "baeu-backend";
+
+  // Logs → Loki (Grafana Cloud).
+  // NOTE: the installed @opentelemetry/sdk-logs is 0.55.x, whose LoggerProvider
+  // takes the resource in the constructor and attaches processors via
+  // addLogRecordProcessor(). The previous code passed `{ processors: [...] }`
+  // (a >=0.200 API) which 0.55 silently ignored → the exporter was never
+  // attached and NO logs reached Loki, and without a resource they'd land as
+  // `unknown_service`. Fix both here.
   const loggerProvider = new LoggerProvider({
-    processors: [new BatchLogRecordProcessor(new OTLPLogExporter())],
+    resource: new Resource({ "service.name": serviceName }),
   });
+  loggerProvider.addLogRecordProcessor(
+    new BatchLogRecordProcessor(new OTLPLogExporter())
+  );
   logs.setGlobalLoggerProvider(loggerProvider);
+
+  // Bridge console.* → OTEL logs. Nothing emits log records on its own (no
+  // winston/pino here, and auto-instrumentation doesn't capture console), so
+  // the app's `[baeu]` lines would never reach Loki. Keep stdout behavior and
+  // additionally emit a structured log record. Guarded so logging can't crash
+  // the API or recurse.
+  const otelLogger = logs.getLogger(serviceName);
+  const SEVERITY = {
+    debug: [5, "DEBUG"],
+    log: [9, "INFO"],
+    info: [9, "INFO"],
+    warn: [13, "WARN"],
+    error: [17, "ERROR"],
+  };
+  const stringifyArg = (a) => {
+    if (typeof a === "string") return a;
+    if (a instanceof Error) return a.stack || a.message;
+    try {
+      return JSON.stringify(a);
+    } catch {
+      return String(a);
+    }
+  };
+  for (const method of Object.keys(SEVERITY)) {
+    const original = console[method].bind(console);
+    const [severityNumber, severityText] = SEVERITY[method];
+    console[method] = (...args) => {
+      original(...args);
+      try {
+        otelLogger.emit({
+          severityNumber,
+          severityText,
+          body: args.map(stringifyArg).join(" "),
+        });
+      } catch {
+        /* never let logging break the app */
+      }
+    };
+  }
 
   const sdk = new NodeSDK({
     serviceName: process.env.OTEL_SERVICE_NAME ?? "baeu-backend",
@@ -69,9 +116,15 @@ if (endpoint && endpoint.trim().length > 0) {
   }
 
   const shutdown = () => {
-    sdk
-      .shutdown()
-      .catch((err) => console.error("[otel] shutdown error:", err));
+    // Flush both pipelines on SIGTERM (Railway sleep/redeploy) so batched
+    // traces/logs aren't dropped when the container pauses.
+    Promise.allSettled([sdk.shutdown(), loggerProvider.shutdown()]).then(
+      (results) => {
+        for (const r of results) {
+          if (r.status === "rejected") console.error("[otel] shutdown error:", r.reason);
+        }
+      }
+    );
   };
   process.once("SIGTERM", shutdown);
   process.once("SIGINT", shutdown);

--- a/backend/src/services/AnalyticsService.js
+++ b/backend/src/services/AnalyticsService.js
@@ -83,7 +83,55 @@ function computeRetention(dayKeys, now = new Date()) {
   };
 }
 
-export const _internals = { computeRetention };
+// Response time as a learning signal. Speed on correct answers is a fluency /
+// automaticity proxy: recall that's both fast AND correct is becoming automatic,
+// while slow-correct is effortful retrieval and fast-wrong is guessing. We split
+// every timed attempt into a speed×accuracy quadrant and surface an
+// automaticity rate (fast-correct ÷ all correct).
+const FAST_MS = 6000; // ≤6s on a correct answer ≈ automatic recall
+
+function responseTimeStats(attempts, fastMs = FAST_MS) {
+  const timed = attempts.filter(
+    (a) => typeof a.response_ms === 'number' && a.response_ms >= 0
+  );
+  const speedAccuracy = { fastCorrect: 0, slowCorrect: 0, fastWrong: 0, slowWrong: 0 };
+  if (!timed.length) {
+    return {
+      count: 0,
+      avgMs: null,
+      medianMs: null,
+      avgCorrectMs: null,
+      avgWrongMs: null,
+      automaticityRate: null,
+      fastThresholdMs: fastMs,
+      speedAccuracy,
+    };
+  }
+  const avg = (arr) =>
+    arr.length ? Math.round(arr.reduce((s, v) => s + v, 0) / arr.length) : null;
+  const all = timed.map((a) => a.response_ms).sort((x, y) => x - y);
+  const mid = Math.floor(all.length / 2);
+  const median = all.length % 2 ? all[mid] : Math.round((all[mid - 1] + all[mid]) / 2);
+  const correct = timed.filter((a) => a.correct).map((a) => a.response_ms);
+  const wrong = timed.filter((a) => !a.correct).map((a) => a.response_ms);
+  for (const a of timed) {
+    const fast = a.response_ms <= fastMs;
+    if (a.correct) speedAccuracy[fast ? 'fastCorrect' : 'slowCorrect'] += 1;
+    else speedAccuracy[fast ? 'fastWrong' : 'slowWrong'] += 1;
+  }
+  return {
+    count: timed.length,
+    avgMs: avg(all),
+    medianMs: median,
+    avgCorrectMs: avg(correct),
+    avgWrongMs: avg(wrong),
+    automaticityRate: correct.length ? speedAccuracy.fastCorrect / correct.length : null,
+    fastThresholdMs: fastMs,
+    speedAccuracy,
+  };
+}
+
+export const _internals = { computeRetention, responseTimeStats };
 
 function fillDays(seriesMap, days) {
   const out = [];
@@ -198,6 +246,7 @@ export async function learnerAnalytics({ userId, days = 30 }) {
     },
     daily: fillDays(series, days),
     retention,
+    responseTime: responseTimeStats(windowed),
     errorTagCounts: errorCounts,
     toughestExercises: toughest,
     responseTimeTrend: responseTrend,

--- a/backend/tests/analytics.test.js
+++ b/backend/tests/analytics.test.js
@@ -65,6 +65,38 @@ test('computeRetention: streaks and D1/D7 comeback rates are deterministic', () 
   assert.equal(r.d7ComebackRate, 3 / 3);
 });
 
+test('responseTimeStats: quadrants, automaticity, and averages', () => {
+  const A = (correct, ms) => ({ correct, response_ms: ms });
+  const stats = Analytics._internals.responseTimeStats(
+    [
+      A(true, 2000), // fast correct
+      A(true, 9000), // slow correct
+      A(false, 1000), // fast wrong
+      A(false, 12000), // slow wrong
+      A(true, 4000), // fast correct
+      { correct: true }, // no response_ms → ignored
+    ],
+    6000
+  );
+  assert.equal(stats.count, 5, 'untimed attempt excluded');
+  assert.deepEqual(stats.speedAccuracy, {
+    fastCorrect: 2,
+    slowCorrect: 1,
+    fastWrong: 1,
+    slowWrong: 1,
+  });
+  assert.equal(stats.automaticityRate, 2 / 3); // 2 fast-correct of 3 correct
+  assert.equal(stats.avgCorrectMs, Math.round((2000 + 9000 + 4000) / 3));
+  assert.equal(stats.medianMs, 4000); // sorted [1000,2000,4000,9000,12000]
+});
+
+test('responseTimeStats: empty input is null-safe', () => {
+  const s = Analytics._internals.responseTimeStats([]);
+  assert.equal(s.count, 0);
+  assert.equal(s.automaticityRate, null);
+  assert.deepEqual(s.speedAccuracy, { fastCorrect: 0, slowCorrect: 0, fastWrong: 0, slowWrong: 0 });
+});
+
 test('learnerAnalytics: includes retention block', async () => {
   const user = await memoryStore.getUserByEmail('a@example.com');
   const session = await Practice.startSession({ userId: user.id });

--- a/frontend/src/pages/Results.jsx
+++ b/frontend/src/pages/Results.jsx
@@ -79,6 +79,17 @@ export default function Results() {
         </p>
       </Card>
 
+      {data.retention && (
+        <Card title="Habit" subtitle="Consistency drives spaced repetition">
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3" data-testid="results-retention">
+            <Mini label="Active days" value={data.retention.activeDays} />
+            <Mini label="Current streak" value={`${data.retention.currentStreak}d`} />
+            <Mini label="Longest streak" value={`${data.retention.longestStreak}d`} />
+            <Mini label="Return next day" value={pctOrDash(data.retention.d1ComebackRate)} />
+          </div>
+        </Card>
+      )}
+
       <Card title="Response time" subtitle="Average ms per correct answer">
         {data.responseTimeTrend.length === 0 ? (
           <p className="text-gray-500 text-sm">No timing data yet — answer a few more cards.</p>
@@ -86,6 +97,27 @@ export default function Results() {
           <ResponseTrend rows={data.responseTimeTrend} />
         )}
       </Card>
+
+      {data.responseTime && data.responseTime.count > 0 && (
+        <Card
+          title="Pace & automaticity"
+          subtitle={`Fast = ≤${Math.round(data.responseTime.fastThresholdMs / 1000)}s`}
+        >
+          <div className="grid grid-cols-3 gap-3 mb-4">
+            <Mini label="Median" value={`${(data.responseTime.medianMs / 1000).toFixed(1)}s`} />
+            <Mini
+              label="Avg (correct)"
+              value={data.responseTime.avgCorrectMs ? `${(data.responseTime.avgCorrectMs / 1000).toFixed(1)}s` : '—'}
+            />
+            <Mini label="Automatic recall" value={pctOrDash(data.responseTime.automaticityRate)} />
+          </div>
+          <SpeedAccuracy sa={data.responseTime.speedAccuracy} />
+          <p className="text-xs text-gray-500 mt-3">
+            Fast + correct means the answer is becoming automatic. Fast + wrong is
+            usually guessing; slow + wrong is where to slow down and review.
+          </p>
+        </Card>
+      )}
 
       <Card title="Toughest exercises" subtitle="Lowest accuracy among items you've seen ≥2 times">
         {data.toughestExercises.length === 0 ? (
@@ -157,6 +189,36 @@ function Stat({ label, value }) {
     <div className="bg-white rounded-xl shadow-card border border-gray-100 p-4">
       <div className="text-xs font-medium text-gray-500 uppercase tracking-wide">{label}</div>
       <div className="font-heading text-3xl font-bold text-gray-900 mt-1">{value}</div>
+    </div>
+  );
+}
+
+function Mini({ label, value }) {
+  return (
+    <div className="text-center">
+      <div className="font-heading text-2xl font-bold text-gray-900">{value}</div>
+      <div className="text-xs text-gray-500">{label}</div>
+    </div>
+  );
+}
+
+function pctOrDash(r) {
+  return r == null ? '—' : `${Math.round(r * 100)}%`;
+}
+
+function SpeedAccuracy({ sa }) {
+  const cell = (label, n, cls) => (
+    <div className={`rounded-lg p-3 ${cls}`}>
+      <div className="font-heading text-xl font-bold">{n}</div>
+      <div className="text-xs leading-tight mt-0.5">{label}</div>
+    </div>
+  );
+  return (
+    <div className="grid grid-cols-2 gap-2" data-testid="results-speed-accuracy">
+      {cell('Fast + correct (automatic)', sa.fastCorrect, 'bg-green-50 text-green-800')}
+      {cell('Slow + correct (effortful)', sa.slowCorrect, 'bg-secondary-50 text-secondary-800')}
+      {cell('Fast + wrong (guessing)', sa.fastWrong, 'bg-amber-50 text-amber-800')}
+      {cell('Slow + wrong (struggling)', sa.slowWrong, 'bg-red-50 text-red-800')}
     </div>
   );
 }


### PR DESCRIPTION
Two follow-ups after verifying the learning intelligence in prod.

## 1. Logs to Loki (ops observability)
Traces (Tempo) and metrics (Prometheus) were already flowing — the "0 traces" gap was stale (Railway sleeps, so traces only exist shortly after traffic; a live request produced 13 traces). The real gap was **logs**:
- `LoggerProvider` was constructed with `{ processors: [...] }` (a ≥0.200 API) but the installed `@opentelemetry/sdk-logs` is **0.55.x**, which ignores it → the OTLP log exporter was never attached. Fixed to the 0.55 API (`addLogRecordProcessor`).
- No resource was set → logs would land as `unknown_service`. Set `service.name`.
- Bridge `console.*` → OTEL logs (no winston/pino; auto-instrumentation doesn't capture console) so `[baeu]` lines actually ship. Flush logger on SIGTERM.
- Added `@opentelemetry/resources` as a direct dep.

## 2. Response-time learning signals
`learnerAnalytics` gains a `responseTime` block: avg/median, avg correct vs wrong, **automaticity rate** (fast-correct ÷ correct), and a **speed×accuracy quadrant** (fast/slow × correct/wrong) — speed on correct answers is a fluency proxy. Surfaced in Results (new "Habit" + "Pace & automaticity" cards, alongside the D1/D7 retention).

## Verification
- Backend `npm test`: 107/107 (+ responseTimeStats tests).
- Frontend build: green.
- Post-merge: will verify Loki shows `baeu-backend` logs and analytics returns the new block in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)