### PR TITLE
Learning signals: forgetting/leeches + per-skill pace

### DIFF
--- a/backend/src/services/AnalyticsService.js
+++ b/backend/src/services/AnalyticsService.js
@@ -9,8 +9,10 @@
 
 import { getStore } from '../config/db.js';
 import { getMasteryMap } from './MasteryService.js';
+import { getSrsMap } from './SrsService.js';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+const MATURE_INTERVAL_DAYS = 21; // SRS items spaced ≥3 weeks are "mature"
 
 function dayKey(ts) {
   return new Date(ts).toISOString().slice(0, 10);
@@ -131,7 +133,62 @@ function responseTimeStats(attempts, fastMs = FAST_MS) {
   };
 }
 
-export const _internals = { computeRetention, responseTimeStats };
+// Forgetting / leeches from the per-item SRS state. Lapses (a previously-known
+// item answered wrong) are the clearest "I forgot this" signal. We surface the
+// worst offenders ("leeches"), how much is in active relearn, what's due now,
+// and how much has reached a mature (long) interval.
+function computeForgetting(srsRows, now = Date.now()) {
+  const rows = Array.isArray(srsRows) ? srsRows : [];
+  const lapsesOf = (r) => Number(r.lapses) || 0;
+  const dueMs = (r) => (r.due_at ? new Date(r.due_at).getTime() : 0);
+  const totalLapses = rows.reduce((s, r) => s + lapsesOf(r), 0);
+  const leeches = rows
+    .filter((r) => lapsesOf(r) >= 2)
+    .sort((a, b) => lapsesOf(b) - lapsesOf(a))
+    .slice(0, 10)
+    .map((r) => ({
+      exerciseId: r.exercise_id,
+      lapses: lapsesOf(r),
+      intervalDays: Number(r.interval_days) || 0,
+      ease: Number(r.ease) || null,
+    }));
+  return {
+    trackedItems: rows.length,
+    totalLapses,
+    itemsInRelearn: rows.filter((r) => lapsesOf(r) > 0 && (Number(r.repetitions) || 0) === 0).length,
+    dueNow: rows.filter((r) => dueMs(r) <= now).length,
+    matureItems: rows.filter((r) => (Number(r.interval_days) || 0) >= MATURE_INTERVAL_DAYS).length,
+    leeches,
+  };
+}
+
+// Average response time per skill — which skills are fast (fluent) vs slow
+// (effortful). Drawn from timed attempts' skill_tags.
+function responseTimeBySkill(attempts, limit = 10) {
+  const by = new Map();
+  for (const a of attempts) {
+    if (typeof a.response_ms !== 'number' || a.response_ms < 0) continue;
+    for (const skill of a.skill_tags || []) {
+      if (!by.has(skill)) by.set(skill, { sum: 0, n: 0, correct: 0 });
+      const g = by.get(skill);
+      g.sum += a.response_ms;
+      g.n += 1;
+      if (a.correct) g.correct += 1;
+    }
+  }
+  return [...by.entries()]
+    .map(([skill, g]) => ({
+      skill,
+      attempts: g.n,
+      avgMs: Math.round(g.sum / g.n),
+      accuracy: g.correct / g.n,
+    }))
+    .filter((r) => r.attempts >= 2)
+    .sort((a, b) => b.avgMs - a.avgMs)
+    .slice(0, limit);
+}
+
+export const _internals = { computeRetention, responseTimeStats, computeForgetting, responseTimeBySkill };
 
 function fillDays(seriesMap, days) {
   const out = [];
@@ -235,6 +292,11 @@ export async function learnerAnalytics({ userId, days = 30 }) {
   const practiceDays = new Set(attempts.map((a) => dayKey(a.created_at)));
   const retention = computeRetention(practiceDays);
 
+  // Forgetting / leeches from per-item SRS state (lifetime, not windowed —
+  // forgetting is about the whole deck). No-op-safe if SRS is unavailable.
+  const srsMap = await getSrsMap(userId);
+  const forgetting = computeForgetting([...srsMap.values()]);
+
   const totalsWindow = windowed.length;
   const totalsCorrect = windowed.filter((a) => a.correct).length;
   return {
@@ -247,6 +309,8 @@ export async function learnerAnalytics({ userId, days = 30 }) {
     daily: fillDays(series, days),
     retention,
     responseTime: responseTimeStats(windowed),
+    responseBySkill: responseTimeBySkill(windowed),
+    forgetting,
     errorTagCounts: errorCounts,
     toughestExercises: toughest,
     responseTimeTrend: responseTrend,

--- a/backend/tests/analytics.test.js
+++ b/backend/tests/analytics.test.js
@@ -90,6 +90,41 @@ test('responseTimeStats: quadrants, automaticity, and averages', () => {
   assert.equal(stats.medianMs, 4000); // sorted [1000,2000,4000,9000,12000]
 });
 
+test('computeForgetting: leeches, relearn, due, mature from SRS rows', () => {
+  const now = Date.parse('2026-06-13T12:00:00Z');
+  const rows = [
+    { exercise_id: 'leech', lapses: 4, repetitions: 0, interval_days: 0, ease: 1.6, due_at: '2026-06-13T11:00:00Z' }, // overdue, in relearn
+    { exercise_id: 'shaky', lapses: 2, repetitions: 3, interval_days: 5, ease: 2.1, due_at: '2026-06-20T00:00:00Z' }, // leech but not due
+    { exercise_id: 'mature', lapses: 0, repetitions: 6, interval_days: 30, ease: 2.6, due_at: '2026-07-10T00:00:00Z' }, // mature
+    { exercise_id: 'fresh', lapses: 0, repetitions: 1, interval_days: 1, ease: 2.5, due_at: '2026-06-13T06:00:00Z' }, // due now
+  ];
+  const f = Analytics._internals.computeForgetting(rows, now);
+  assert.equal(f.trackedItems, 4);
+  assert.equal(f.totalLapses, 6);
+  assert.equal(f.itemsInRelearn, 1); // only 'leech' (lapses>0 & reps===0)
+  assert.equal(f.dueNow, 2); // 'leech' and 'fresh'
+  assert.equal(f.matureItems, 1); // 'mature' (interval>=21)
+  assert.deepEqual(f.leeches.map((l) => l.exerciseId), ['leech', 'shaky']); // lapses>=2, sorted desc
+});
+
+test('responseTimeBySkill: avg per skill from timed attempts', () => {
+  const rows = [
+    { correct: true, response_ms: 2000, skill_tags: ['particles'] },
+    { correct: false, response_ms: 8000, skill_tags: ['particles'] },
+    { correct: true, response_ms: 1000, skill_tags: ['hangul'] },
+    { correct: true, response_ms: 3000, skill_tags: ['hangul'] },
+    { correct: true, skill_tags: ['hangul'] }, // untimed → ignored
+  ];
+  const r = Analytics._internals.responseTimeBySkill(rows);
+  const particles = r.find((x) => x.skill === 'particles');
+  const hangul = r.find((x) => x.skill === 'hangul');
+  assert.equal(particles.avgMs, 5000);
+  assert.equal(particles.attempts, 2);
+  assert.equal(hangul.avgMs, 2000);
+  assert.equal(hangul.accuracy, 1);
+  assert.equal(r[0].skill, 'particles'); // slowest first
+});
+
 test('responseTimeStats: empty input is null-safe', () => {
   const s = Analytics._internals.responseTimeStats([]);
   assert.equal(s.count, 0);

--- a/frontend/src/pages/Results.jsx
+++ b/frontend/src/pages/Results.jsx
@@ -119,6 +119,55 @@ export default function Results() {
         </Card>
       )}
 
+      {data.forgetting && data.forgetting.trackedItems > 0 && (
+        <Card title="Forgetting & leeches" subtitle="From your spaced-repetition schedule">
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4" data-testid="results-forgetting">
+            <Mini label="Tracked items" value={data.forgetting.trackedItems} />
+            <Mini label="Due now" value={data.forgetting.dueNow} />
+            <Mini label="In relearn" value={data.forgetting.itemsInRelearn} />
+            <Mini label="Mature (≥21d)" value={data.forgetting.matureItems} />
+          </div>
+          {data.forgetting.leeches.length === 0 ? (
+            <p className="text-gray-500 text-sm">No leeches yet — nothing you've repeatedly forgotten. 👍</p>
+          ) : (
+            <>
+              <p className="text-xs text-gray-500 mb-2">
+                Leeches — items you keep forgetting (most lapses first):
+              </p>
+              <ul className="space-y-1.5" data-testid="results-leeches">
+                {data.forgetting.leeches.map((l) => (
+                  <li key={l.exerciseId} className="flex items-center justify-between gap-3 text-sm">
+                    <span className="text-gray-600 truncate" title={l.exerciseId}>
+                      #{String(l.exerciseId).slice(0, 8)}
+                    </span>
+                    <span className="flex items-center gap-3 text-gray-700">
+                      <span className="text-red-600 font-semibold">{l.lapses} lapses</span>
+                      <span className="text-gray-400">interval {l.intervalDays}d</span>
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+        </Card>
+      )}
+
+      {data.responseBySkill && data.responseBySkill.length > 0 && (
+        <Card title="Pace by skill" subtitle="Where recall is slow vs fluent">
+          <ul className="space-y-1.5" data-testid="results-pace-by-skill">
+            {data.responseBySkill.map((s) => (
+              <li key={s.skill} className="flex items-center justify-between gap-3 text-sm">
+                <span className="text-gray-700">{s.skill}</span>
+                <span className="flex items-center gap-3 text-gray-600">
+                  <span>{(s.avgMs / 1000).toFixed(1)}s</span>
+                  <span className="text-gray-400">{Math.round(s.accuracy * 100)}% · {s.attempts} att</span>
+                </span>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
+
       <Card title="Toughest exercises" subtitle="Lowest accuracy among items you've seen ≥2 times">
         {data.toughestExercises.length === 0 ? (
           <p className="text-gray-500 text-sm">Not enough repetitions yet to spot patterns.</p>


### PR DESCRIPTION
More learning observability signals from existing data (no new tables).

- **forgetting** (from per-item SRS): totalLapses, itemsInRelearn, dueNow, matureItems (interval ≥21d), and **leeches** (items with the most lapses — what you keep forgetting). Lifetime; no-op-safe if SRS unavailable.
- **responseBySkill**: avg response time per skill from timed attempts — which skills are fluent vs effortful.

Surfaced in Results as "Forgetting & leeches" and "Pace by skill" cards.

Verification: backend 109/109 (+ computeForgetting, responseTimeBySkill tests); frontend build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)