### PR TITLE
Review forecast + readable/speakable toughest & leech items

### DIFF
--- a/backend/src/services/AnalyticsService.js
+++ b/backend/src/services/AnalyticsService.js
@@ -209,12 +209,40 @@ function sentenceErrorBreakdown(attempts) {
   return { textAttempts, textWrong, byTag };
 }
 
+// Review forecast: how many SRS items come due, bucketed, so the learner has a
+// return hook ("3 items due tomorrow"). Buckets are by UTC calendar day.
+function computeForecast(srsRows, now = Date.now()) {
+  const rows = Array.isArray(srsRows) ? srsRows : [];
+  const startOfToday = (() => {
+    const d = new Date(now);
+    d.setUTCHours(0, 0, 0, 0);
+    return d.getTime();
+  })();
+  const endOfToday = startOfToday + DAY_MS;
+  const endOfTomorrow = startOfToday + 2 * DAY_MS;
+  const endOf7 = startOfToday + 7 * DAY_MS;
+  let overdue = 0;
+  let today = 0;
+  let tomorrow = 0;
+  let next7 = 0;
+  for (const r of rows) {
+    const due = r.due_at ? new Date(r.due_at).getTime() : null;
+    if (due == null) continue;
+    if (due < startOfToday) overdue += 1;
+    else if (due < endOfToday) today += 1;
+    else if (due < endOfTomorrow) tomorrow += 1;
+    else if (due < endOf7) next7 += 1;
+  }
+  return { overdue, today, tomorrow, next7Days: next7, dueNow: overdue + today };
+}
+
 export const _internals = {
   computeRetention,
   responseTimeStats,
   computeForgetting,
   responseTimeBySkill,
   sentenceErrorBreakdown,
+  computeForecast,
 };
 
 function fillDays(seriesMap, days) {
@@ -322,7 +350,25 @@ export async function learnerAnalytics({ userId, days = 30 }) {
   // Forgetting / leeches from per-item SRS state (lifetime, not windowed —
   // forgetting is about the whole deck). No-op-safe if SRS is unavailable.
   const srsMap = await getSrsMap(userId);
-  const forgetting = computeForgetting([...srsMap.values()]);
+  const srsRows = [...srsMap.values()];
+  const forgetting = computeForgetting(srsRows);
+  const forecast = computeForecast(srsRows);
+
+  // Enrich item lists (toughest, leeches) with the exercise prompt + answer so
+  // the UI shows readable, speakable content instead of bare ids. Best-effort:
+  // a missing lookup just leaves the id. One bounded read of published items.
+  let exMap = new Map();
+  try {
+    const published = await store.listPublishedExercises({});
+    for (const e of published) {
+      exMap.set(e.id, { prompt: e.prompt, answer: e.correct_answer ?? null, type: e.type });
+    }
+  } catch {
+    /* enrichment is optional */
+  }
+  const labelOf = (id) => exMap.get(id) || {};
+  const toughestLabeled = toughest.map((t) => ({ ...t, ...labelOf(t.exerciseId) }));
+  forgetting.leeches = forgetting.leeches.map((l) => ({ ...l, ...labelOf(l.exerciseId) }));
 
   const totalsWindow = windowed.length;
   const totalsCorrect = windowed.filter((a) => a.correct).length;
@@ -339,8 +385,9 @@ export async function learnerAnalytics({ userId, days = 30 }) {
     responseBySkill: responseTimeBySkill(windowed),
     sentenceErrors: sentenceErrorBreakdown(windowed),
     forgetting,
+    forecast,
     errorTagCounts: errorCounts,
-    toughestExercises: toughest,
+    toughestExercises: toughestLabeled,
     responseTimeTrend: responseTrend,
     masteryByLevel,
   };

--- a/backend/tests/analytics.test.js
+++ b/backend/tests/analytics.test.js
@@ -107,6 +107,25 @@ test('computeForgetting: leeches, relearn, due, mature from SRS rows', () => {
   assert.deepEqual(f.leeches.map((l) => l.exerciseId), ['leech', 'shaky']); // lapses>=2, sorted desc
 });
 
+test('computeForecast: buckets SRS due dates by calendar day', () => {
+  const now = Date.parse('2026-06-13T12:00:00Z');
+  const rows = [
+    { due_at: '2026-06-10T00:00:00Z' }, // overdue
+    { due_at: '2026-06-13T06:00:00Z' }, // today (earlier today)
+    { due_at: '2026-06-13T20:00:00Z' }, // today (later today)
+    { due_at: '2026-06-14T09:00:00Z' }, // tomorrow
+    { due_at: '2026-06-17T00:00:00Z' }, // within 7 days
+    { due_at: '2026-06-25T00:00:00Z' }, // beyond 7 → uncounted
+    { due_at: null }, // ignored
+  ];
+  const f = Analytics._internals.computeForecast(rows, now);
+  assert.equal(f.overdue, 1);
+  assert.equal(f.today, 2);
+  assert.equal(f.tomorrow, 1);
+  assert.equal(f.next7Days, 1);
+  assert.equal(f.dueNow, 3); // overdue + today
+});
+
 test('responseTimeBySkill: avg per skill from timed attempts', () => {
   const rows = [
     { correct: true, response_ms: 2000, skill_tags: ['particles'] },

--- a/frontend/src/pages/Progress.jsx
+++ b/frontend/src/pages/Progress.jsx
@@ -199,6 +199,7 @@ function LearningSignals({ a }) {
   const rt = a.responseTime;
   const f = a.forgetting;
   const se = a.sentenceErrors;
+  const fc = a.forecast;
   const hasAny =
     (rt && rt.count > 0) ||
     (f && f.trackedItems > 0) ||
@@ -217,9 +218,16 @@ function LearningSignals({ a }) {
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
         {rt && rt.count > 0 && <Mini label="Automatic recall" value={pct(rt.automaticityRate)} />}
         {rt && rt.medianMs != null && <Mini label="Median pace" value={`${(rt.medianMs / 1000).toFixed(1)}s`} />}
-        {f && f.trackedItems > 0 && <Mini label="Due to review" value={f.dueNow} />}
+        {fc && <Mini label="Due now" value={fc.dueNow} />}
+        {fc && <Mini label="Due tomorrow" value={fc.tomorrow} />}
         {f && f.trackedItems > 0 && <Mini label="Keep forgetting" value={f.leeches.length} />}
       </div>
+      {fc && fc.dueNow > 0 && (
+        <p className="text-xs text-gray-500 mt-2">
+          {fc.dueNow} item{fc.dueNow === 1 ? '' : 's'} ready to review now
+          {fc.tomorrow > 0 ? `, ${fc.tomorrow} more tomorrow` : ''}.
+        </p>
+      )}
       {sentenceTags.length > 0 && (
         <div className="mt-4">
           <p className="text-xs text-gray-500 mb-2">Where you slip on sentences (free-text answers):</p>

--- a/frontend/src/pages/Results.jsx
+++ b/frontend/src/pages/Results.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { api } from '../api.js';
 import { useToast } from '../components/Toast.jsx';
+import { speak, hasHangul, speechSupported } from '../utils/speech.js';
 
 // Deep learner analytics — complements /progress (which is the lightweight
 // streak/skill view). Surfaces:
@@ -119,6 +120,25 @@ export default function Results() {
         </Card>
       )}
 
+      {data.forecast && (
+        <Card title="Review forecast" subtitle="When items come due">
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3" data-testid="results-forecast">
+            <Mini label="Due now" value={data.forecast.dueNow} />
+            <Mini label="Tomorrow" value={data.forecast.tomorrow} />
+            <Mini label="Next 7 days" value={data.forecast.next7Days} />
+            <Mini label="Overdue" value={data.forecast.overdue} />
+          </div>
+          {data.forecast.dueNow > 0 && (
+            <a
+              href="#/practice?focus=weak"
+              className="inline-flex mt-4 items-center gap-2 bg-secondary-500 hover:bg-secondary-600 text-white font-semibold py-2 px-4 rounded-lg transition-all no-underline"
+            >
+              Review {data.forecast.dueNow} due now →
+            </a>
+          )}
+        </Card>
+      )}
+
       {data.forgetting && data.forgetting.trackedItems > 0 && (
         <Card title="Forgetting & leeches" subtitle="From your spaced-repetition schedule">
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4" data-testid="results-forgetting">
@@ -137,10 +157,8 @@ export default function Results() {
               <ul className="space-y-1.5" data-testid="results-leeches">
                 {data.forgetting.leeches.map((l) => (
                   <li key={l.exerciseId} className="flex items-center justify-between gap-3 text-sm">
-                    <span className="text-gray-600 truncate" title={l.exerciseId}>
-                      #{String(l.exerciseId).slice(0, 8)}
-                    </span>
-                    <span className="flex items-center gap-3 text-gray-700">
+                    <ItemLabel item={l} />
+                    <span className="flex items-center gap-3 text-gray-700 flex-shrink-0">
                       <span className="text-red-600 font-semibold">{l.lapses} lapses</span>
                       <span className="text-gray-400">interval {l.intervalDays}d</span>
                     </span>
@@ -175,10 +193,8 @@ export default function Results() {
           <ul className="space-y-2" data-testid="results-toughest">
             {data.toughestExercises.map((e) => (
               <li key={e.exerciseId} className="flex items-center justify-between gap-3 text-sm">
-                <span className="text-gray-600 truncate" title={e.exerciseId}>
-                  #{String(e.exerciseId).slice(0, 8)}
-                </span>
-                <span className="flex items-center gap-3 text-gray-700">
+                <ItemLabel item={e} />
+                <span className="flex items-center gap-3 text-gray-700 flex-shrink-0">
                   <span>{e.attempts} att</span>
                   <span className={e.accuracy < 0.34 ? 'text-red-600 font-semibold' : ''}>
                     {Math.round(e.accuracy * 100)}%
@@ -288,6 +304,31 @@ function Mini({ label, value }) {
       <div className="font-heading text-2xl font-bold text-gray-900">{value}</div>
       <div className="text-xs text-gray-500">{label}</div>
     </div>
+  );
+}
+
+// Readable label for an exercise item (toughest / leech). Shows the prompt text
+// instead of a bare id, with a speaker for any Korean content it contains.
+function ItemLabel({ item }) {
+  const label = item.prompt || `#${String(item.exerciseId).slice(0, 8)}`;
+  const ko = hasHangul(item.prompt) ? item.prompt : hasHangul(item.answer) ? item.answer : null;
+  return (
+    <span className="flex items-center gap-1.5 min-w-0">
+      <span className="text-gray-700 truncate" title={label} lang={hasHangul(label) ? 'ko' : undefined}>
+        {label}
+      </span>
+      {ko && speechSupported() && (
+        <button
+          type="button"
+          onClick={() => speak(ko)}
+          aria-label="Play Korean pronunciation"
+          title="Play pronunciation"
+          className="inline-flex items-center justify-center w-6 h-6 rounded-full text-gray-400 hover:text-primary-600 hover:bg-primary-50 transition-colors flex-shrink-0"
+        >
+          <span aria-hidden>🔊</span>
+        </button>
+      )}
+    </span>
   );
 }
 


### PR DESCRIPTION
Two follow-ups to round out the learning observability.

## Review forecast (return hook)
`learnerAnalytics.forecast`: SRS items bucketed by when they come due — `dueNow`, `tomorrow`, `next7Days`, `overdue`. Surfaced in:
- **Progress**: "Due now" / "Due tomorrow" minis + a one-line nudge.
- **Results**: "Review forecast" card with a "Review N due now →" CTA into focused practice.

## Readable + speakable items
`toughestExercises` and `forgetting.leeches` are now enriched with the exercise `prompt` + `answer` (one bounded read of published items). The UI shows the actual question text instead of `#a1b2c3d4`, with a 🔊 Korean TTS button for any Hangul content.

## Verification
- Backend 115/115 (+ computeForecast test).
- Frontend build green.
- Post-merge: prod learner smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)