### PR TITLE
feat(content+e2e): particle-contrast MC drills + live IDOR prod smoke

### DIFF
--- a/backend/src/db/topik1Content.js
+++ b/backend/src/db/topik1Content.js
@@ -499,6 +499,47 @@ function particlesModule() {
   }));
 }
 
+// Particle-contrast multiple choice. "Which particle?" is the #1 beginner error,
+// but the catalog only trained it as fill_blank. This reuses the already-verified
+// PARTICLES answers and turns each into a discrimination drill — restricted to the
+// UNAMBIGUOUS skills (object 을/를, location 에/에서) and items with no accepted
+// variants, so a distractor is never secretly also-correct. Distractors are
+// particles from a different function (clearly wrong), plus the sibling location
+// particle for the high-value 에/에서 contrast. Additive + idempotent (distinct
+// prompt prefix from the fill_blank module, so seed dedupe won't collide).
+function particleContrastModule() {
+  const eligible = PARTICLES.filter(
+    (p) => (p.skill === 'object_marker' || p.skill === 'location') && p.alts.length === 0
+  );
+  return eligible.map(({ sentence, en, answer, skill }) => {
+    const distractors =
+      skill === 'location'
+        ? [answer === '에' ? '에서' : '에', '를', '가']
+        : ['에', '에서', '가'];
+    const options = shuffle([
+      { id: 'a', text: answer },
+      ...distractors.slice(0, 3).map((t, i) => ({ id: 'bcd'[i], text: t })),
+    ]);
+    const explanation =
+      skill === 'location'
+        ? `에 marks a destination or static location; 에서 marks where an action happens. Here it is ${answer}.`
+        : `${answer} is the object particle (을 after a final consonant, 를 after a vowel). Here it is ${answer}.`;
+    return {
+      module_slug: 'particles',
+      type: 'multiple_choice',
+      difficulty: 'medium',
+      prompt: `Choose the correct particle: ${sentence} ("${en}")`,
+      options,
+      correct_answer: options.find((o) => o.text === answer).id,
+      accepted_answers: [answer],
+      explanation,
+      skill_tags: ['particles', 'particle_contrast', skill],
+      metadata: {},
+      status: 'published',
+    };
+  });
+}
+
 function verbsModule() {
   const out = [];
   for (const [en, dict, polite, formal] of VERBS) {
@@ -810,6 +851,7 @@ export function buildTopik1Content() {
     ...greetingsModule(),
     ...numbersModule(),
     ...particlesModule(),
+    ...particleContrastModule(),
     ...verbsModule(),
     ...vocabDailyModule(),
     ...patternsModule(),

--- a/backend/tests/seed.test.js
+++ b/backend/tests/seed.test.js
@@ -41,6 +41,21 @@ test('catalog has a hard tier and reinforced grammar drills', () => {
   assert.ok(wordOrder.length >= 10, `expected word_order coverage, got ${wordOrder.length}`);
 });
 
+test('particle-contrast drills are well-formed multiple choice', () => {
+  const items = buildSampleExercises();
+  const pc = items.filter((i) => (i.skill_tags || []).includes('particle_contrast'));
+  assert.ok(pc.length >= 10, `expected a particle-contrast set, got ${pc.length}`);
+  for (const it of pc) {
+    assert.equal(it.type, 'multiple_choice');
+    assert.equal(it.options.length, 4, `4 options expected: ${it.prompt}`);
+    const texts = it.options.map((o) => o.text);
+    assert.equal(new Set(texts).size, texts.length, `no duplicate options: ${it.prompt}`);
+    const correct = it.options.find((o) => o.id === it.correct_answer);
+    assert.ok(correct, `correct_answer must map to an option: ${it.prompt}`);
+    assert.equal(correct.text, it.accepted_answers[0], `correct option matches answer: ${it.prompt}`);
+  }
+});
+
 test('seedNewExercises is additive and idempotent (no duplicate prompts)', async () => {
   memoryStore.reset();
   const first = await runSeedIfEmpty();

--- a/frontend/e2e/prod-idor-smoke.spec.js
+++ b/frontend/e2e/prod-idor-smoke.spec.js
@@ -1,0 +1,94 @@
+// Production IDOR smoke. Proves at the DEPLOYED boundary that an authenticated
+// user (B) cannot read or mutate another user's (A) practice session — the
+// two-account proof repeatedly requested by audits, complementing the in-process
+// route test (backend/tests/practiceRoutes.test.js).
+//
+// Run with:
+//   npm run e2e:prod-idor-smoke
+//
+// Opt-in via E2E_PROD_IDOR_SMOKE=1 because it writes to the real backend: it
+// creates TWO synthetic learners and deletes both before exiting (best-effort).
+
+import { test, expect } from '@playwright/test';
+
+const SHOULD_RUN = process.env.E2E_PROD_IDOR_SMOKE === '1';
+const API_BASE =
+  process.env.E2E_API_BASE_URL ||
+  process.env.VITE_API_BASE_URL ||
+  'https://baeu-backend-production.up.railway.app';
+
+test.skip(!SHOULD_RUN, 'set E2E_PROD_IDOR_SMOKE=1 to run');
+
+const api = (p) => `${API_BASE}${p}`;
+
+// Each user gets its own request context so the Better Auth session cookie
+// (http-only) is isolated per learner — exactly two distinct identities.
+async function newUser(playwright, label) {
+  const ctx = await playwright.request.newContext({ baseURL: API_BASE });
+  const email = `audit-idor-${label}-${Date.now()}-${Math.random().toString(16).slice(2)}@test.local`;
+  const res = await ctx.post(api('/api/auth/sign-up/email'), {
+    headers: { 'Content-Type': 'application/json' },
+    data: { email, password: 'audit-idor-1234', name: `IDOR ${label}` },
+  });
+  expect(res.ok(), `signup ${label} should succeed (${res.status()})`).toBeTruthy();
+  return { ctx, email };
+}
+
+async function deleteSelf(user) {
+  try {
+    await user.ctx.post(api('/api/auth/delete-user'), {
+      headers: { 'Content-Type': 'application/json' },
+      data: {},
+    });
+  } catch (e) {
+    console.warn(`[prod-idor] cleanup ${user.email} failed (non-fatal):`, e?.message);
+  } finally {
+    await user.ctx.dispose();
+  }
+}
+
+test('prod: user B cannot read or mutate user A practice session (IDOR)', async ({ playwright }) => {
+  const userA = await newUser(playwright, 'a');
+  const userB = await newUser(playwright, 'b');
+
+  try {
+    // A owns a session and pulls a real question from it (positive control).
+    const sessionRes = await userA.ctx.post(api('/api/v1/practice/sessions'), {
+      headers: { 'Content-Type': 'application/json' },
+      data: {},
+    });
+    expect(sessionRes.ok(), 'A creates a session').toBeTruthy();
+    const sessionId = (await sessionRes.json()).id;
+    expect(sessionId, 'session id present').toBeTruthy();
+
+    const aNext = await userA.ctx.get(api(`/api/v1/practice/next?sessionId=${encodeURIComponent(sessionId)}`));
+    expect(aNext.status(), 'A can read its own next question (200)').toBe(200);
+    const exerciseId = (await aNext.json()).id;
+    expect(exerciseId, 'exercise id present').toBeTruthy();
+
+    // B attacks A's session on all three ownership-guarded routes.
+    const bNext = await userB.ctx.get(api(`/api/v1/practice/next?sessionId=${encodeURIComponent(sessionId)}`));
+    expect(bNext.status(), 'B next on A session => 403').toBe(403);
+    expect(await bNext.json()).toEqual({ error: 'session_forbidden' });
+
+    const bAnswer = await userB.ctx.post(api('/api/v1/practice/answer'), {
+      headers: { 'Content-Type': 'application/json' },
+      data: { sessionId, exerciseId, answer: 'x' },
+    });
+    expect(bAnswer.status(), 'B answer on A session => 403').toBe(403);
+    expect(await bAnswer.json()).toEqual({ error: 'session_forbidden' });
+
+    const bSummary = await userB.ctx.get(api(`/api/v1/practice/sessions/${encodeURIComponent(sessionId)}/summary`));
+    expect(bSummary.status(), 'B summary on A session => 403').toBe(403);
+    expect(await bSummary.json()).toEqual({ error: 'session_forbidden' });
+
+    // Positive control: A still owns its session after B's failed attacks.
+    const aSummary = await userA.ctx.get(api(`/api/v1/practice/sessions/${encodeURIComponent(sessionId)}/summary`));
+    expect(aSummary.status(), 'A can read its own summary (200)').toBe(200);
+
+    console.log(`[prod-idor] proved isolation. A=${userA.email} B=${userB.email}`);
+  } finally {
+    await deleteSelf(userA);
+    await deleteSelf(userB);
+  }
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "e2e:install": "playwright install --with-deps chromium",
     "e2e:prod-smoke": "E2E_PROD_SMOKE=1 E2E_NO_WEBSERVER=1 E2E_BASE_URL=https://baeu-learning.vercel.app playwright test e2e/prod-smoke.spec.js",
     "e2e:prod-admin-smoke": "E2E_PROD_ADMIN_SMOKE=1 E2E_NO_WEBSERVER=1 E2E_BASE_URL=https://baeu-learning.vercel.app playwright test e2e/prod-admin-smoke.spec.js",
+    "e2e:prod-idor-smoke": "E2E_PROD_IDOR_SMOKE=1 E2E_NO_WEBSERVER=1 E2E_BASE_URL=https://baeu-learning.vercel.app playwright test e2e/prod-idor-smoke.spec.js",
     "test:e2e:audit": "npm run e2e:prod-smoke -- --workers=1"
   },
   "dependencies": {

--- a/project-state.md
+++ b/project-state.md
@@ -1,0 +1,112 @@
+---
+project: Baeu Learning
+repo_path: /Users/joaoadair/Documents/AI/Baeu_Learning
+generated_at: 2026-06-13T20:08:00-03:00 (refresh pós-sprint 06-13)
+source_branch: main
+source_commit: 3e732dd (2026-06-13, PR #7)
+freshness: doc-reconcile 2026-06-13 — reflete fechamento dos PRs #2–#7 (merged em main, CI verde, deployados)
+confidence: high (código + git log + gaps-live PR proofs)
+---
+
+# Project State — Baeu Learning
+
+> **NOTA 2026-06-13:** o sprint de 13/06 (PRs #2–#7, todos merged/deployados) fechou
+> praticamente todo o backlog técnico/UX. As seções abaixo foram atualizadas; o
+> histórico anterior de "Gate UX: BLOCK" foi superado. Fonte de verdade viva: topo de
+> `gaps-live.md`.
+
+## Verified Runtime State (2026-06-13)
+
+- Frontend prod: `https://baeu-learning.vercel.app` → SPA Vite hash-router. Sprint 06-13
+  corrigiu `lang` (`en` + spans `lang="ko"`), meta/OG, título dinâmico por rota.
+- Backend prod: `https://baeu-backend-production.up.railway.app/api/v1/health` →
+  `{"ok":true,"store":"pg"}`. Health canônico é `/api/v1/health` (`/api/health` sem v1 = 404).
+- Google OAuth: **OCULTO por flag** (`VITE_GOOGLE_SIGN_IN_ENABLED` default-off,
+  `Auth.jsx`). Sem credencial real no Railway; não há mais CTA quebrado em prod.
+  Reabrir só se quiser Google login de verdade.
+- SRS: SM-2 por item em `backend/src/services/SrsService.js`; lógica pura extraída
+  para `backend/src/lib/srs/` (asset de fleet, sprint 06-13). Sinais de aprendizado
+  (automaticity, forgetting/leeches, pace por skill, sentence-error fino, review
+  forecast) surfaced em Results + Progress (PRs #3–#7).
+- Landing: demo SRS real de 6 cartas usando o engine (itens errados ressurgem) —
+  não é mais o MC hardcoded.
+- Reset de senha existe (rota `#/reset-password`, e-mail via Resend).
+
+## Veredito estratégico (run 1214 — NÃO re-derivar)
+
+- **LIFESTYLE legítimo.** ICE 7.7 lifestyle / 4.7 B2C. Não perseguir GTM B2C.
+- Extrair SRS engine como lib interna da fleet (ver gaps-live/backlog C).
+- Cohort B2B (tutor + alunos) só se surgir organicamente.
+
+## Decisões Round 2 (2026-06-07)
+
+- **LIFESTYLE declarado; sem GTM B2C.** Nenhum funil pago, nenhuma landing de venda.
+- **Kill suave datado:** sem uso (João = 0 prática) até **2026-09-07** → arquivar como
+  lifestyle (export dump SRS/attempts, README "ARCHIVED", sleep Railway, manter Vercel estático).
+- **Extração SRS lib ganha o MESMO prazo (2026-09-07):** `nextSrsState` é função pura;
+  acoplamento é só `getStore` — extrair antes do checkpoint para o arquivamento não
+  matar o único asset de fleet.
+- **Quick-wins custo zero PERMITIDOS apesar do gate BLOCK:** esconder botão Google
+  (flag), `lang` correto, meta/OG — ~2h total.
+- **NSM pessoal:** `dias com prática SRS concluída` (não MAU, não signups).
+- Re-smoke 2026-06-07-1557: zero commits desde 06-06; OAuth social segue 404 live;
+  placar 0 fechado em prod / 9 persistem / 2 não-testáveis / 1 fechado por baseline (#12).
+- **Re-run 2026-06-07-2334:** botão Google OCULTADO em prod (flag
+  `VITE_GOOGLE_SIGN_IN_ENABLED` default-off, `Auth.jsx:15/:249`; deploy 21:43
+  `dpl_FnZtuj8UZbXjgC83eLfxQjMZSP4Z` = latest READY Vercel). **ATENÇÃO: mudança
+  NÃO COMMITADA — prod à frente do git; commitar Auth.jsx + .env.example.**
+  `lang="en"`, 0 og:, sample hardcoded e 3 camadas de tokens persistem. Cold start
+  segue NOT_OBSERVED (3 runs).
+
+## Gates
+
+- Gate UX: **DESBLOQUEADO** — o BLOCK de 06-07 (1×P0 + 4×P1) foi fechado pelo sprint
+  06-13. P0 #1 (demo SRS landing), #3 lang, #4 meta/OG, #5 TTS, #10 cold-start: todos
+  FECHADOS + deployados. Ver topo de `gaps-live.md`.
+- Fluxo learner first-value: **PROVADO** em prod (melhor média UX do portfólio).
+- Observabilidade: traces (Tempo), logs (Loki) e métricas (Prometheus) PROVADOS live (PR #3).
+
+## Envs (NOMES apenas — valores nunca)
+
+- Backend (Railway): `PORT`, `NODE_ENV`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`,
+  `ADMIN_TOKEN`, `CORS_ORIGIN`, `DATABASE_URL` (Neon), `GOOGLE_CLIENT_ID`*,
+  `GOOGLE_CLIENT_SECRET`* (*ausentes em prod → OAuth morto), `RESEND_API_KEY`,
+  `EMAIL_FROM`, `LLM_API_KEY` (OpenRouter), `LLM_BASE_URL`, `LLM_MODEL`.
+- Frontend (Vercel): `VITE_API_BASE_URL`.
+
+## O que funciona vs mock
+
+- Funciona em prod: auth e-mail/senha + reset, practice loop, grading, SRS scheduling,
+  progress/streak, sinais de aprendizado, demo SRS na landing, lessons/modules, admin (token).
+- Oculto por flag (não morto): botão Google (sem credencial real; escondido default-off).
+- Sem mock-mode no produto; conteúdo é seed real (TOPIK 1, ~440 itens, hard tier 50).
+
+## Canonical Commands
+
+Ver `AGENTS.md` → Safe Commands. Health read-only:
+`curl https://baeu-backend-production.up.railway.app/api/v1/health`
+
+## Do Not Do
+
+- Não criar GTM/landing B2C (decisão 1214).
+- Não usar alias antigo `baeu-learning-api`.
+- Não rodar geração LLM de admin em escala (custo OpenRouter).
+- Não ler/printar `.env*` ou valores de env.
+
+## Next Actions (ordem ICE)
+
+Os sprints de 13/06 (PRs #2–#7, deployados) fecharam quase tudo — UX, demo SRS na
+landing, sinais de aprendizado, observabilidade, hard tier, índice /modules.
+
+**Backlog atual (decisão 2026-06-13: eixos 2 + 3 + smoke):**
+1. **IDOR live (2 contas)** — prova no boundary deployado que o User B não lê a sessão
+   do User A. Código já cobre via `backend/tests/practiceRoutes.test.js`; falta o smoke
+   prod. → `frontend/e2e/prod-idor-smoke.spec.js` (branch `feat/idor-smoke-and-content-pedagogy`).
+2. **Conteúdo/pedagogia** — reduzir dominância de `translation` (~75%) com tipos
+   discriminantes: conjugação `fill_blank`, contraste de partículas `multiple_choice`,
+   reconhecimento por áudio (TTS ko-KR já existe), + hard de gramática. Lote aditivo
+   via `npm run seed:new`.
+3. **Manutenção viva:** NSM pessoal = dias com prática SRS. Soft-kill datado 2026-09-07
+   se uso = 0. Não abrir GTM B2C sem sinal orgânico (regra 2-de-3, ver `gaps-live.md`).
+
+**Sem pendências de higiene de deploy abertas:** PRs #2–#7 commitados + merged + deployados.


### PR DESCRIPTION
## What

Eixos 2 (gaps honestos) + 3 (conteúdo/pedagogia) + smoke da rodada 2026-06-13.

### Security — IDOR live (último P1-watch)
- `frontend/e2e/prod-idor-smoke.spec.js`: prova no boundary deployado que User B recebe **403 `session_forbidden`** em `next`/`answer`/`summary` da sessão de User A, com controle positivo (A lê a própria = 200) e cleanup das 2 contas. Complementa o `practiceRoutes.test.js` in-process.
- `npm run e2e:prod-idor-smoke` passou em prod ✅.

### Content/pedagogy — contraste de partículas
- Novo `particleContrastModule`: 16 drills `multiple_choice` ("qual partícula?" — 을/를, 에/에서), o erro nº1 de iniciante, antes só treinado como `fill_blank`.
- Reusa coreano já verificado (`PARTICLES`), restrito a categorias inequívocas sem `alts` → distrator nunca é secretamente correto. Travado por teste.
- Já seedado em prod via `seed:new` (aditivo): catálogo em 491 publicados.

### Docs
- `project-state.md` reconciliado à realidade pós-PRs #2–#7.

## Verification
- Backend **116/116**.
- `e2e:prod-idor-smoke` ✅ · `e2e:prod-smoke` ✅ (sem regressão no learner path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)