### PR TITLE
fix(mobile-ux): global button-hover bug + 44px targets; past/tense drills

### DIFF
--- a/backend/src/db/modules.js
+++ b/backend/src/db/modules.js
@@ -32,8 +32,8 @@ export const MODULES = [
   },
   {
     slug: 'verbs-present',
-    title: 'Verbs — Present Tense',
-    description: 'Dictionary form, polite -아/어요, and formal -ㅂ니다 across common verbs.',
+    title: 'Verbs & Conjugation',
+    description: 'Dictionary form, polite -아/어요, formal -ㅂ니다, and past -았/었어요 across common verbs.',
     order_index: 50,
     icon: '하',
   },

--- a/backend/src/db/topik1Content.js
+++ b/backend/src/db/topik1Content.js
@@ -108,6 +108,39 @@ const VERBS = [
   ['to study', '공부하다', '공부해요', '공부합니다'],
 ];
 
+// Past polite (-았/었어요). Forms are verified explicitly (not derived) to avoid
+// vowel-harmony mistakes. Past tense was previously only present inside hard
+// sentences — these are dedicated conjugation drills. [en, dictionary, past].
+const VERBS_PAST = [
+  ['to go', '가다', '갔어요'],
+  ['to come', '오다', '왔어요'],
+  ['to eat', '먹다', '먹었어요'],
+  ['to drink', '마시다', '마셨어요'],
+  ['to do', '하다', '했어요'],
+  ['to see / watch', '보다', '봤어요'],
+  ['to buy', '사다', '샀어요'],
+  ['to give', '주다', '줬어요'],
+  ['to read', '읽다', '읽었어요'],
+  ['to learn', '배우다', '배웠어요'],
+  ['to know', '알다', '알았어요'],
+  ['to live', '살다', '살았어요'],
+  ['to wait', '기다리다', '기다렸어요'],
+  ['to like', '좋아하다', '좋아했어요'],
+  ['to study', '공부하다', '공부했어요'],
+];
+
+// Tense discrimination: pick the right form for an English sentence. Trains
+// recognition of present vs past vs future (-(으)ㄹ 거예요) — a core TOPIK-1 skill
+// not previously drilled in isolation. All four options are real, verified forms.
+const TENSE_MC = [
+  { en: 'I went to school yesterday.', answer: '갔어요', distractors: ['가요', '갈 거예요', '가세요'], skill: 'past' },
+  { en: 'I will eat tomorrow.', answer: '먹을 거예요', distractors: ['먹어요', '먹었어요', '먹으세요'], skill: 'future' },
+  { en: 'I watched a movie.', answer: '봤어요', distractors: ['봐요', '볼 거예요', '보세요'], skill: 'past' },
+  { en: 'I bought bread.', answer: '샀어요', distractors: ['사요', '살 거예요', '사세요'], skill: 'past' },
+  { en: 'I will learn Korean.', answer: '배울 거예요', distractors: ['배워요', '배웠어요', '배우세요'], skill: 'future' },
+  { en: 'I study every day.', answer: '공부해요', distractors: ['공부했어요', '공부할 거예요', '공부하세요'], skill: 'present' },
+];
+
 const PARTICLES = [
   { sentence: '저___ 학생입니다.', en: 'I am a student.', answer: '는', alts: [], skill: 'topic_marker' },
   { sentence: '오빠___ 멋있어요.', en: 'My older brother is cool.', answer: '는', alts: [], skill: 'topic_marker' },
@@ -540,6 +573,47 @@ function particleContrastModule() {
   });
 }
 
+// Past-tense conjugation drills (fill_blank). New skill: 'past'.
+function pastTenseModule() {
+  return VERBS_PAST.map(([en, dict, past]) => ({
+    module_slug: 'verbs-present',
+    type: 'fill_blank',
+    difficulty: 'medium',
+    prompt: `Past polite (-았/었어요) form of ${dict} (${en})`,
+    correct_answer: past,
+    accepted_answers: [past],
+    explanation: `${dict} → ${past} (past, polite).`,
+    skill_tags: ['verbs', 'verb_conjugation', 'past'],
+    metadata: {},
+    status: 'published',
+  }));
+}
+
+// Tense-discrimination multiple choice (present vs past vs future).
+function tenseContrastModule() {
+  return TENSE_MC.map(({ en, answer, distractors, skill }) => {
+    const options = shuffle([
+      { id: 'a', text: answer },
+      ...distractors.slice(0, 3).map((t, i) => ({ id: 'bcd'[i], text: t })),
+    ]);
+    return {
+      module_slug: 'verbs-present',
+      type: 'multiple_choice',
+      difficulty: 'medium',
+      prompt: `Pick the correct verb form: "${en}"`,
+      options,
+      correct_answer: options.find((o) => o.text === answer).id,
+      accepted_answers: [answer],
+      explanation: `"${en}" → ${answer} (${skill}).`,
+      // Keep to 3 tags: the selector adds a per-tag bonus, so a higher tag count
+      // would over-serve these items relative to the rest of the catalog.
+      skill_tags: ['verb_conjugation', 'tense', skill],
+      metadata: {},
+      status: 'published',
+    };
+  });
+}
+
 function verbsModule() {
   const out = [];
   for (const [en, dict, polite, formal] of VERBS) {
@@ -853,6 +927,8 @@ export function buildTopik1Content() {
     ...particlesModule(),
     ...particleContrastModule(),
     ...verbsModule(),
+    ...pastTenseModule(),
+    ...tenseContrastModule(),
     ...vocabDailyModule(),
     ...patternsModule(),
     ...wordOrderModule(),

--- a/backend/tests/seed.test.js
+++ b/backend/tests/seed.test.js
@@ -41,6 +41,28 @@ test('catalog has a hard tier and reinforced grammar drills', () => {
   assert.ok(wordOrder.length >= 10, `expected word_order coverage, got ${wordOrder.length}`);
 });
 
+test('past-tense + tense-contrast drills exist and are well-formed', () => {
+  const items = buildSampleExercises();
+  const past = items.filter(
+    (i) => i.type === 'fill_blank' && (i.skill_tags || []).includes('past')
+  );
+  assert.ok(past.length >= 12, `expected past-tense drills, got ${past.length}`);
+  for (const it of past) {
+    assert.ok(it.correct_answer && it.accepted_answers.includes(it.correct_answer));
+  }
+  const tense = items.filter(
+    (i) => i.type === 'multiple_choice' && (i.skill_tags || []).includes('tense')
+  );
+  assert.ok(tense.length >= 4, `expected tense-contrast MC, got ${tense.length}`);
+  for (const it of tense) {
+    assert.equal(it.options.length, 4, `4 options expected: ${it.prompt}`);
+    // selector adds a per-tag bonus; keep these from dominating the catalog.
+    assert.ok((it.skill_tags || []).length <= 3, `<=3 tags expected: ${it.prompt}`);
+    const correct = it.options.find((o) => o.id === it.correct_answer);
+    assert.ok(correct && correct.text === it.accepted_answers[0]);
+  }
+});
+
 test('particle-contrast drills are well-formed multiple choice', () => {
   const items = buildSampleExercises();
   const pc = items.filter((i) => (i.skill_tags || []).includes('particle_contrast'));

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -340,7 +340,7 @@ function Header({ user, role, active, onLogout }) {
           <span className="font-heading font-bold text-xl text-gray-900 leading-none">Baeu</span>
           <span className="text-gray-400 text-sm hidden sm:inline">· Korean practice</span>
         </a>
-        <nav className="w-full sm:w-auto sm:ml-auto flex flex-nowrap sm:flex-wrap items-center gap-1 sm:gap-3 text-sm overflow-x-auto sm:overflow-visible [-webkit-overflow-scrolling:touch] [scrollbar-width:none]">
+        <nav className="w-full sm:w-auto sm:ml-auto flex flex-wrap items-center gap-1 sm:gap-3 text-sm">
           {user && (
             <>
               <NavLink href="#/" active={active === 'practice'}>Practice</NavLink>
@@ -357,7 +357,7 @@ function Header({ user, role, active, onLogout }) {
               <a
                 href="#/account"
                 data-testid="account-link"
-                className={`px-2 py-1.5 rounded-md no-underline transition-colors whitespace-nowrap ${
+                className={`px-3 py-2.5 min-h-[44px] inline-flex items-center rounded-md no-underline transition-colors whitespace-nowrap ${
                   active === 'account' ? 'text-primary-700 font-semibold' : 'text-gray-600 hover:text-primary-500'
                 }`}
               >
@@ -368,7 +368,7 @@ function Header({ user, role, active, onLogout }) {
                 type="button"
                 data-testid="logout-btn"
                 onClick={onLogout}
-                className="px-2 py-1.5 rounded-md text-gray-500 hover:text-primary-500 hover:bg-primary-50 transition-colors bg-transparent whitespace-nowrap"
+                className="px-3 py-2.5 min-h-[44px] inline-flex items-center rounded-md text-gray-500 hover:text-primary-500 hover:bg-primary-50 transition-colors bg-transparent whitespace-nowrap"
               >
                 Log out
               </button>
@@ -384,7 +384,7 @@ function NavLink({ href, active, children }) {
   return (
     <a
       href={href}
-      className={`px-2 sm:px-3 py-1.5 rounded-md no-underline transition-colors whitespace-nowrap ${
+      className={`px-3 py-2.5 min-h-[44px] inline-flex items-center rounded-md no-underline transition-colors whitespace-nowrap ${
         active
           ? 'bg-primary-50 text-primary-700 font-semibold'
           : 'text-gray-600 hover:text-primary-500'

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -84,25 +84,34 @@ h2, h3, h4, h5, h6 {
   color: var(--color-text-primary);
 }
 
+/* Buttons are styled by Tailwind utility classes throughout the app. We only
+   set type/cursor globally here. Do NOT set a background on `button` or
+   `button:hover`: a global `button:hover` (specificity 0,1,1) outranks Tailwind's
+   `.bg-white` (0,1,0), which painted every tapped option dark-red with unreadable
+   text on mobile (where :hover sticks after a tap). */
 button {
+  font-family: inherit;
+  cursor: pointer;
+}
+
+/* Starter-template defaults, scoped to UNCLASSED buttons only (there are none in
+   the app today) so a stray bare <button> still looks intentional without ever
+   overriding a Tailwind-classed button. */
+button:not([class]) {
   border-radius: 0.5rem;
   border: 1px solid transparent;
   padding: 0.6em 1.2em;
   font-size: 1em;
   font-weight: 500;
-  font-family: inherit;
   background-color: var(--color-primary);
   color: white;
-  cursor: pointer;
   transition: all 0.25s ease;
 }
-
-button:hover {
+button:not([class]):hover {
   background-color: var(--color-primary-dark);
   transform: translateY(-1px);
 }
 
-button:focus,
 button:focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
@@ -134,8 +143,10 @@ img {
   height: auto;
 }
 
-/* Focus styles for accessibility */
-*:focus {
+/* Focus styles for accessibility — only for keyboard/AT users (:focus-visible),
+   so mouse clicks and taps on cards/links don't leave a stuck red outline that
+   reads like an error state. */
+*:focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }

--- a/frontend/src/pages/Auth.jsx
+++ b/frontend/src/pages/Auth.jsx
@@ -91,7 +91,7 @@ export default function Auth({ notice = null }) {
 
   return (
     <div className="max-w-5xl mx-auto grid grid-cols-1 lg:grid-cols-5 gap-8 items-start">
-      <section className="lg:col-span-3 space-y-6 animate-fade-in" data-testid="landing-hero">
+      <section className="order-2 lg:order-1 lg:col-span-3 space-y-6 animate-fade-in" data-testid="landing-hero">
         <div>
           <p className="text-primary-600 font-semibold text-sm tracking-wide uppercase mb-2">
             Korean practice, daily
@@ -145,7 +145,7 @@ export default function Auth({ notice = null }) {
         )}
       </section>
 
-      <div className="lg:col-span-2">
+      <div className="order-1 lg:order-2 lg:col-span-2">
         <div className="bg-white rounded-xl shadow-card border border-gray-100 p-6 sm:p-7 animate-fade-in">
           {notice && (
             <div

--- a/frontend/src/pages/EndlessPractice.jsx
+++ b/frontend/src/pages/EndlessPractice.jsx
@@ -475,7 +475,7 @@ function SpeakButton({ text, className = '' }) {
       }}
       aria-label="Play Korean pronunciation"
       title="Play pronunciation"
-      className={`inline-flex items-center justify-center w-7 h-7 rounded-full text-gray-500 hover:text-primary-600 hover:bg-primary-50 transition-colors ${className}`}
+      className={`inline-flex items-center justify-center w-9 h-9 text-base rounded-full text-gray-500 hover:text-primary-600 hover:bg-primary-50 transition-colors ${className}`}
     >
       <span aria-hidden>🔊</span>
     </button>


### PR DESCRIPTION
## Deep mobile UX audit (390px) + hand-authored content

Audited the deployed app at a real 390px viewport with Nielsen heuristics + WCAG 2.5.5 target-size, captured evidence, fixed in code, and **re-verified on a local prod build**.

### P0 — global button-hover bug (marquee finding)
`index.css` carried a starter-template `button:hover { background: var(--color-primary-dark) }`. Its specificity (0,1,1) beat Tailwind's `.bg-white` (0,1,0), and on mobile `:hover` sticks after a tap → **every tapped MC option turned dark-red (#991b1b) with dark text; the learner couldn't read their own selected answer** (contrast ~1.5:1). Scoped the starter styles to `button:not([class])`. Proven on a local build: selected option is now `primary-50` bg + `primary-900` text (`anyDarkRedLightButton: none`).

### P1 — touch targets & nav
- Nav links / Account / Log out: 32px → **44px** (`min-h-[44px]`, WCAG 2.5.5).
- TTS speak button: 28px → 36px.
- Nav **wraps** instead of horizontal-scroll, so "Log out" is no longer clipped off-screen at 390px (measured `scrollWidth 438 > clientWidth 358`).

### P2 — focus + layout
- `*:focus` → `*:focus-visible`: removes the stuck red outline that painted card borders on tap as if an error.
- Auth card is **first on mobile** (order utilities) so the daily user logs in without scrolling past the whole hero; hero stays left on desktop.

### Content (authored by hand — OpenRouter credits exhausted)
- **15 past-tense conjugation drills** (`fill_blank`, new skill `past`), forms verified explicitly.
- **6 tense-discrimination MC** (present/past/future), capped at 3 `skill_tags` so the selector's per-tag bonus doesn't over-serve them.
- Verbs module retitled "Verbs & Conjugation". Translation share 74% → 71%.

### Verification
- Backend **117/117** (incl. new content + selector-diversity regression caught & fixed).
- Frontend e2e **20/20** (3 prod smokes gated).
- Mobile fixes verified on local prod build via Playwright at 390px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)