### PR TITLE
fix(results+practice): intentional empty states + accurate free-text placeholders

### DIFF
--- a/frontend/src/pages/EndlessPractice.jsx
+++ b/frontend/src/pages/EndlessPractice.jsx
@@ -17,6 +17,21 @@ const TAG_LABELS = {
   unknown: 'unclassified',
 };
 
+// Free-text prompt hint. Several distinct drills share `type: 'translation'`
+// — "Romanize …", "Translate to Korean …", and "What does … mean" — but each
+// expects a different answer (romanization / Korean / English). The old code
+// always said "meaning in English", which was wrong for the first two. Key off
+// the prompt wording so the placeholder matches what's actually expected.
+function placeholderFor(question) {
+  const prompt = (question.prompt || '').toLowerCase();
+  if (/\bromaniz/.test(prompt)) return 'Type the romanization (e.g. "bap")…';
+  if (/to korean|in korean|in hangul/.test(prompt)) return 'Type your answer in Korean…';
+  if (question.type === 'translation' || /translate|\bmean(s|ing)?\b/.test(prompt)) {
+    return 'Type the meaning in English…';
+  }
+  return 'Type your answer…';
+}
+
 export default function EndlessPractice({ moduleSlug = null, moduleTitle = null, initialFocus = null }) {
   const [session, setSession] = useState(null);
   const [question, setQuestion] = useState(null);
@@ -287,11 +302,7 @@ function QuestionCard({ question, answer, setAnswer, submit, loading }) {
           value={answer}
           onChange={(e) => setAnswer(e.target.value)}
           onKeyDown={(e) => { if (e.key === 'Enter') submit(); }}
-          placeholder={
-            question.type === 'translation'
-              ? 'Type the meaning in English...'
-              : 'Type your answer...'
-          }
+          placeholder={placeholderFor(question)}
           className="w-full px-4 py-3 text-lg border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none"
         />
       )}

--- a/frontend/src/pages/Results.jsx
+++ b/frontend/src/pages/Results.jsx
@@ -61,23 +61,35 @@ export default function Results() {
       </div>
 
       <Card title="Daily activity" subtitle={`Last ${days} days`}>
-        <div className="flex items-end gap-1 h-32" data-testid="results-daily">
-          {data.daily.map((d) => {
-            const h = Math.max(2, (d.attempts / maxDaily) * 100);
-            const accRatio = d.attempts ? d.correct / d.attempts : 0;
-            return (
-              <div key={d.date} className="flex-1 flex flex-col items-center justify-end" title={`${d.date}: ${d.attempts} attempts, ${d.correct} correct`}>
-                <div
-                  className={`w-full rounded-t ${d.attempts === 0 ? 'bg-gray-100' : accRatio >= 0.8 ? 'bg-green-500' : accRatio >= 0.5 ? 'bg-secondary-500' : 'bg-red-400'}`}
-                  style={{ height: `${h}%` }}
-                />
-              </div>
-            );
-          })}
-        </div>
-        <p className="text-xs text-gray-500 mt-2">
-          Bar color = accuracy that day. Hover for raw counts.
-        </p>
+        {data.totals.attempts === 0 ? (
+          <EmptyHint>
+            No activity in this window yet — finish a practice session and your
+            daily volume shows up here.
+          </EmptyHint>
+        ) : (
+          <>
+            {/* The lane gives the chart a visible region so sparse data reads as
+                "a quiet chart" rather than an empty/broken card. */}
+            <div className="flex items-end gap-1 h-32 rounded-lg bg-gray-50 px-2 pt-2" data-testid="results-daily">
+              {data.daily.map((d) => {
+                const accRatio = d.attempts ? d.correct / d.attempts : 0;
+                // Empty days get a thin, visible tick; active days a real bar.
+                const h = d.attempts ? Math.max(8, (d.attempts / maxDaily) * 100) : 4;
+                return (
+                  <div key={d.date} className="flex-1 flex flex-col items-center justify-end" title={`${d.date}: ${d.attempts} attempts, ${d.correct} correct`}>
+                    <div
+                      className={`w-full rounded-t ${d.attempts === 0 ? 'bg-gray-200' : accRatio >= 0.8 ? 'bg-green-500' : accRatio >= 0.5 ? 'bg-secondary-500' : 'bg-red-400'}`}
+                      style={{ height: `${h}%` }}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+            <p className="text-xs text-gray-500 mt-2">
+              Bar color = accuracy that day. Hover for raw counts.
+            </p>
+          </>
+        )}
       </Card>
 
       {data.retention && (
@@ -93,7 +105,10 @@ export default function Results() {
 
       <Card title="Response time" subtitle="Average ms per correct answer">
         {data.responseTimeTrend.length === 0 ? (
-          <p className="text-gray-500 text-sm">No timing data yet — answer a few more cards.</p>
+          <EmptyHint>
+            No timing data yet — answer a few more cards and your speed trend
+            appears here.
+          </EmptyHint>
         ) : (
           <ResponseTrend rows={data.responseTimeTrend} />
         )}
@@ -276,6 +291,16 @@ const ERROR_LABELS = {
   romanization_dependency: 'romanization',
   unknown: 'unclassified',
 };
+
+// Intentional empty state — a soft dashed panel reads as "nothing here yet"
+// rather than a card that failed to render.
+function EmptyHint({ children }) {
+  return (
+    <div className="rounded-lg bg-gray-50 border border-dashed border-gray-200 px-4 py-6 text-center text-sm text-gray-500">
+      {children}
+    </div>
+  );
+}
 
 function Card({ title, subtitle, children }) {
   return (


### PR DESCRIPTION
## Why
While doing the authenticated sweep (after the dark-mode work), a fresh/low-data account made the **Results** page look incomplete — which is exactly the "features não 100% nas telas" symptom. Nothing was actually missing; the empty/sparse-data states just rendered as broken. Also found a free-text **placeholder** bug in Practice.

## Changes
**Results (`frontend/src/pages/Results.jsx`)**
- `Daily activity`: empty-day bars were `bg-gray-100` at 2% height → invisible on a white card, so the whole chart looked blank. Now: empty window → a soft dashed `EmptyHint` panel; with data → bars sit in a visible lane (`bg-gray-50`) and empty days show a faint visible tick.
- `Response time`: no-data state now uses the same `EmptyHint` panel instead of a bare gray line.
- New shared `EmptyHint` component so empty states read as intentional.

**Practice (`frontend/src/pages/EndlessPractice.jsx`)**
- `placeholderFor(question)` infers the expected answer from the prompt. `type: 'translation'` is shared by three distinct drills, but the placeholder always said *"Type the meaning in English"*:
  - `Romanize …` → `Type the romanization (e.g. "bap")…`
  - `Translate to Korean …` → `Type your answer in Korean…`
  - `What does … mean` → `Type the meaning in English…`

## Verification
- `npm run build` ✓
- Manual browser check (dark mode, fresh account): both empty-state panels render correctly, and the "Translate to Korean" question now shows the Korean placeholder.

## Notes
- Pure frontend/UX; no backend or data-model change. The underlying `type: 'translation'` grouping is unchanged — only the displayed hint adapts.
- Stacks on top of the dark-mode work already on `main`; all changes theme correctly in light & dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)