### PR TITLE
feat(content): +50 non-translation drills for thinnest skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,14 @@
 
 ## Read First
 
+- `project-state.md` — runtime truth, gates, env names, next actions (start here).
+- `gaps-live.md` — CONSOLIDADO (open gaps + grep-index); full history in
+  `gaps-archive-2026-06-07.md`. Append dated entries, never delete archive.
+- `route-map.md` — frontend hash routes + backend API map with verified states.
+- `personas/` — João-learner (primária), tutor B2B (hipotética), linguista cética (adversária).
 - `README.md` — stack, DB schema, endpoints, test users (PT-BR).
 - `DEPLOY.md` — Neon + Railway + Vercel deploy steps and env var names.
 - `RUNBOOK.md` — manual provider/ops steps.
-- `gaps-live.md` — dated audit log + current blockers. Append, never recreate.
 - This repo is on the user's real Mac at `/Users/joaoadair/Documents/AI/Baeu_Learning`.
   Edit only inside this path.
 
@@ -13,6 +17,17 @@
 
 Korean-learning web app (TOPIK 1). Learner first-value path:
 **signup/login -> practice question -> answer feedback -> progress update.**
+
+**Status estratégico (decisão 2026-06-06-1214): LIFESTYLE/PASSION PROJECT.**
+No B2C GTM. ICE 7.7 lifestyle / 4.7 B2C. Best code in the fleet; the SRS engine
+(`backend/src/services/SrsService.js`, SM-2) is an extraction candidate as an
+internal lib. Canonical prod: web `https://baeu-learning.vercel.app` (SPA,
+hash routes), API `https://baeu-backend-production.up.railway.app/api/v1/*`
+(health: `/api/v1/health` — NOT `/api/health`, that's 404).
+
+Known gotchas: Google button renders but OAuth is dead in prod (`GOOGLE_*` envs
+missing — `sign-in/social` returns 404); `<html lang="en">` on a Korean app;
+no meta/OG; two parallel token systems (`styles/designSystem.js` + `theme.js`).
 
 - **Backend** (`backend/`): Node + Express (ESM), Postgres via `pg` on Neon,
   `better-auth` for auth, OpenTelemetry instrumentation, Resend email,

--- a/backend/src/db/topik1Content.js
+++ b/backend/src/db/topik1Content.js
@@ -2,6 +2,7 @@
 // Seed step resolves slug → module_id at insert time.
 
 import { buildDepthContent } from './topik1Depth.js';
+import { buildDepth2Content } from './topik1Depth2.js';
 
 // ---------- VOCAB SOURCE TABLES ----------
 
@@ -937,5 +938,6 @@ export function buildTopik1Content() {
     ...readingModule(),
     ...hardModule(),
     ...buildDepthContent(),
+    ...buildDepth2Content(),
   ];
 }

--- a/backend/src/db/topik1Depth2.js
+++ b/backend/src/db/topik1Depth2.js
@@ -1,0 +1,276 @@
+// Depth expansion #2 — targets the thinnest TOPIK-1 skills by catalog coverage
+// (question words, 있다/없다 existence, location nouns, adjective antonyms +
+// ㅂ/으-irregular conjugation, honorifics/register) and deliberately uses ONLY
+// multiple_choice + fill_blank to pull down the translation-heavy ratio.
+//
+// Every Korean form is authored and verified explicitly — no runtime derivation —
+// because the learner relies on this being correct. Conventions mirror
+// topik1Depth.js: MC options are {id,text}; correct_answer is the option id;
+// accepted_answers carries the literal answer; prompts are distinct from existing
+// ones so the additive seed (dedupe-by-prompt) never collides; skill_tags ≤ 3
+// (the selector adds a per-tag bonus, so more would over-serve these items).
+
+function shuffle(arr) {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+function mc({ module_slug, prompt, answer, distractors, explanation, skill_tags, difficulty = 'medium' }) {
+  const options = shuffle([
+    { id: 'a', text: answer },
+    ...distractors.slice(0, 3).map((t, i) => ({ id: 'bcd'[i], text: t })),
+  ]);
+  return {
+    module_slug,
+    type: 'multiple_choice',
+    difficulty,
+    prompt,
+    options,
+    correct_answer: options.find((o) => o.text === answer).id,
+    accepted_answers: [answer],
+    explanation,
+    skill_tags,
+    metadata: {},
+    status: 'published',
+  };
+}
+
+function fill({ module_slug, prompt, answer, explanation, skill_tags, difficulty = 'medium' }) {
+  return {
+    module_slug,
+    type: 'fill_blank',
+    difficulty,
+    prompt,
+    correct_answer: answer,
+    accepted_answers: [answer],
+    explanation,
+    skill_tags,
+    metadata: {},
+    status: 'published',
+  };
+}
+
+// ---------- QUESTION WORDS (의문사) — module: patterns ----------
+
+// [english meaning, korean question word, romanization]
+const QUESTION_WORDS = [
+  ['what', '뭐', 'mwo'],
+  ['where', '어디', 'eodi'],
+  ['when', '언제', 'eonje'],
+  ['who', '누구', 'nugu'],
+  ['why', '왜', 'wae'],
+  ['how', '어떻게', 'eotteoke'],
+  ['how much (price)', '얼마', 'eolma'],
+  ['how many (with a counter)', '몇', 'myeot'],
+];
+
+// Question word in a real sentence — fill the blank.
+const QUESTION_APPLIED = [
+  { prompt: '___ 가요? (Where are you going?)', answer: '어디', rom: 'eodi' },
+  { prompt: '지금 ___ 해요? (What are you doing now?)', answer: '뭐', rom: 'mwo' },
+  { prompt: '생일이 ___예요? (When is your birthday?)', answer: '언제', rom: 'eonje' },
+  { prompt: '이 사람은 ___예요? (Who is this person?)', answer: '누구', rom: 'nugu' },
+  { prompt: '___ 늦었어요? (Why are you late?)', answer: '왜', rom: 'wae' },
+  { prompt: '이거 ___예요? (How much is this?)', answer: '얼마', rom: 'eolma' },
+  { prompt: '사과가 ___ 개 있어요? (How many apples are there?)', answer: '몇', rom: 'myeot' },
+];
+
+function questionWords() {
+  const out = [];
+  for (const [en, ko] of QUESTION_WORDS) {
+    const pool = QUESTION_WORDS.map((w) => w[1]).filter((w) => w !== ko);
+    out.push(
+      mc({
+        module_slug: 'patterns',
+        prompt: `Which question word means "${en}"?`,
+        answer: ko,
+        distractors: shuffle(pool).slice(0, 3),
+        explanation: `"${en}" = ${ko}.`,
+        skill_tags: ['questions', 'vocabulary'],
+        difficulty: 'easy',
+      })
+    );
+  }
+  for (const c of QUESTION_APPLIED) {
+    out.push(
+      fill({
+        module_slug: 'patterns',
+        prompt: `Fill the question word: ${c.prompt}`,
+        answer: c.answer,
+        explanation: `${c.answer} (${c.rom}).`,
+        skill_tags: ['questions', 'word_order'],
+      })
+    );
+  }
+  return out;
+}
+
+// ---------- 있다 / 없다 EXISTENCE — module: patterns ----------
+
+const EXISTENCE_MC = [
+  { en: 'I have money.', answer: '돈이 있어요', distractors: ['돈이 없어요', '돈이에요', '돈을 사요'] },
+  { en: "There isn't any time.", answer: '시간이 없어요', distractors: ['시간이 있어요', '시간이에요', '시간이 와요'] },
+  { en: 'I have a younger sibling.', answer: '동생이 있어요', distractors: ['동생이 없어요', '동생이에요', '동생을 해요'] },
+  { en: 'There are no questions.', answer: '질문이 없어요', distractors: ['질문이 있어요', '질문이에요', '질문을 해요'] },
+];
+
+function existence() {
+  return EXISTENCE_MC.map((c) =>
+    mc({
+      module_slug: 'patterns',
+      prompt: `Pick the correct sentence: "${c.en}"`,
+      answer: c.answer,
+      distractors: c.distractors,
+      explanation: `있어요 = there is / have; 없어요 = there isn't / don't have. → ${c.answer}.`,
+      skill_tags: ['existence', 'particles'],
+    })
+  );
+}
+
+// ---------- LOCATION NOUNS (위치 명사) — module: vocab-daily ----------
+
+// [english, korean position noun, romanization]
+const POSITIONS = [
+  ['on top of / above', '위', 'wi'],
+  ['under / below', '아래', 'arae'],
+  ['in front of', '앞', 'ap'],
+  ['behind', '뒤', 'dwi'],
+  ['next to / beside', '옆', 'yeop'],
+  ['inside', '안', 'an'],
+  ['outside', '밖', 'bak'],
+];
+
+const POSITION_APPLIED = [
+  { en: 'The book is on the desk.', answer: '책상 위에 있어요', distractors: ['책상 아래에 있어요', '책상 옆에 있어요', '책상 안에 있어요'] },
+  { en: 'The cat is under the chair.', answer: '고양이가 의자 아래에 있어요', distractors: ['고양이가 의자 위에 있어요', '고양이가 의자 앞에 있어요', '고양이가 의자 옆에 있어요'] },
+];
+
+function locations() {
+  const out = [];
+  for (const [en, ko] of POSITIONS) {
+    const pool = POSITIONS.map((p) => p[1]).filter((p) => p !== ko);
+    out.push(
+      mc({
+        module_slug: 'vocab-daily',
+        prompt: `Which position word means "${en}"?`,
+        answer: ko,
+        distractors: shuffle(pool).slice(0, 3),
+        explanation: `"${en}" = ${ko} (used with 에: ${ko}에).`,
+        skill_tags: ['location', 'vocabulary'],
+        difficulty: 'easy',
+      })
+    );
+  }
+  for (const c of POSITION_APPLIED) {
+    out.push(
+      mc({
+        module_slug: 'vocab-daily',
+        prompt: `Pick the correct sentence: "${c.en}"`,
+        answer: c.answer,
+        distractors: c.distractors,
+        explanation: `Position noun + 에 marks where something is. → ${c.answer}.`,
+        skill_tags: ['location', 'existence'],
+      })
+    );
+  }
+  return out;
+}
+
+// ---------- ADJECTIVE ANTONYMS (형용사 반의어) — module: vocab-daily ----------
+
+// [korean adjective, english, korean antonym, antonym english]
+const ANTONYMS = [
+  ['크다', 'big', '작다', ['많다', '좋다', '높다']],
+  ['많다', 'many', '적다', ['작다', '싸다', '낮다']],
+  ['비싸다', 'expensive', '싸다', ['작다', '적다', '나쁘다']],
+  ['덥다', 'hot (weather)', '춥다', ['맵다', '작다', '싸다']],
+  ['좋다', 'good', '나쁘다', ['싸다', '적다', '작다']],
+  ['높다', 'high / tall', '낮다', ['작다', '짧다', '적다']],
+  ['길다', 'long', '짧다', ['작다', '낮다', '적다']],
+  ['빠르다', 'fast', '느리다', ['작다', '낮다', '짧다']],
+];
+
+function antonyms() {
+  return ANTONYMS.map(([ko, en, ant, distractors]) =>
+    mc({
+      module_slug: 'vocab-daily',
+      prompt: `What is the opposite of ${ko} (${en})?`,
+      answer: ant,
+      distractors,
+      explanation: `${ko} (${en}) ↔ ${ant}.`,
+      skill_tags: ['adjectives', 'vocabulary'],
+    })
+  );
+}
+
+// ---------- ADJECTIVE CONJUGATION (ㅂ / 으 irregulars) — module: verbs-present ----
+
+// The polite present 요-form of irregular descriptive verbs — a classic error
+// zone. [dictionary form, correct 요-form, english, [wrong forms]]
+const ADJ_CONJ = [
+  ['춥다', '추워요', 'to be cold', ['춥어요', '추어요', '춥아요']],
+  ['덥다', '더워요', 'to be hot', ['덥어요', '더어요', '덥아요']],
+  ['맵다', '매워요', 'to be spicy', ['맵어요', '매어요', '맵아요']],
+  ['크다', '커요', 'to be big', ['크어요', '크아요', '키요']],
+  ['예쁘다', '예뻐요', 'to be pretty', ['예쁘어요', '예쁘아요', '예뻐어요']],
+  ['바쁘다', '바빠요', 'to be busy', ['바쁘아요', '바쁘어요', '바뻐요']],
+];
+
+function adjConjugation() {
+  return ADJ_CONJ.map(([dict, form, en, wrong]) =>
+    mc({
+      module_slug: 'verbs-present',
+      prompt: `Conjugate ${dict} (${en}) to the polite present 요-form:`,
+      answer: form,
+      distractors: wrong,
+      explanation:
+        `${dict} → ${form}. ` +
+        (['춥다', '덥다', '맵다'].includes(dict)
+          ? 'ㅂ-irregular: 받침 ㅂ → 우 before -어요.'
+          : '으-irregular: the ㅡ drops before the vowel ending.'),
+      skill_tags: ['adjectives', 'verb_conjugation'],
+      difficulty: 'hard',
+    })
+  );
+}
+
+// ---------- HONORIFICS / REGISTER (높임말) — module: greetings ----------
+
+const HONORIFICS_MC = [
+  { prompt: 'Honorific subject marker (e.g. 할아버지___ 오세요 — Grandfather is coming):', answer: '께서', distractors: ['가', '이', '은'], exp: '께서 is the honorific form of 가/이 for a respected subject.' },
+  { prompt: 'Honorific way to say "please eat" (to an elder):', answer: '드세요', distractors: ['먹어요', '먹어', '잡아요'], exp: '드세요 (from 드시다) is the honorific of 먹다.' },
+  { prompt: 'Honorific verb "to be / stay" for a person (e.g. Is your father home?):', answer: '계세요', distractors: ['있어요', '없어요', '이에요'], exp: '계시다 is the honorific of 있다 for people.' },
+  { prompt: 'Honorific way to say "please sleep / good night":', answer: '주무세요', distractors: ['자요', '자', '누워요'], exp: '주무시다 is the honorific of 자다.' },
+  { prompt: 'Honorific word for "name":', answer: '성함', distractors: ['이름', '별명', '제목'], exp: '성함 is the honorific of 이름.' },
+  { prompt: 'Honorific word for "age":', answer: '연세', distractors: ['나이', '시간', '생일'], exp: '연세 is the honorific of 나이.' },
+  { prompt: 'Honorific counter for people (e.g. "three people", to be polite):', answer: '세 분', distractors: ['세 명', '세 개', '세 마리'], exp: '분 is the honorific counter for people (vs the plain 명).' },
+  { prompt: 'Polite way to request "please give me water":', answer: '물 주세요', distractors: ['물 줘', '물 있어요', '물 사요'], exp: '주세요 (from 주다) is the standard polite request form.' },
+];
+
+function honorifics() {
+  return HONORIFICS_MC.map((c) =>
+    mc({
+      module_slug: 'greetings',
+      prompt: c.prompt,
+      answer: c.answer,
+      distractors: c.distractors,
+      explanation: c.exp,
+      skill_tags: ['honorifics', 'register'],
+    })
+  );
+}
+
+export function buildDepth2Content() {
+  return [
+    ...questionWords(),
+    ...existence(),
+    ...locations(),
+    ...antonyms(),
+    ...adjConjugation(),
+    ...honorifics(),
+  ];
+}

--- a/backend/src/instrumentation.js
+++ b/backend/src/instrumentation.js
@@ -83,6 +83,10 @@ if (endpoint && endpoint.trim().length > 0) {
           severityNumber,
           severityText,
           body: args.map(stringifyArg).join(" "),
+          attributes: {
+            service: serviceName,
+            service_name: serviceName,
+          },
         });
       } catch {
         /* never let logging break the app */


### PR DESCRIPTION
## What

Adds **50 hand-authored multiple_choice/fill_blank drills** (`backend/src/db/topik1Depth2.js`) targeting the thinnest TOPIK-1 skills by catalog coverage:

- **Question words** (의문사): what/where/when/who/why/how/how much/how many — concept + applied in sentences
- **있다/없다 existence** + **location nouns** (위/아래/앞/뒤/옆/안/밖)
- **Adjective antonyms** (크다↔작다, 비싸다↔싸다, 덥다↔춥다…)
- **Adjective conjugation** — ㅂ/으 irregulars (춥다→추워요, 예쁘다→예뻐요)
- **Honorifics/register** (께서, 드세요, 계세요, 성함, 연세, 세 분, 주세요)

All forms verified by hand; `skill_tags` capped at 3 (selector per-tag bias); prompts distinct so the additive dedupe-by-prompt seed never collides.

## Why this approach

Pulled the prod Neon DB to drive content by **real diagnostics** — but found **~0 real usage** (118 users are almost all `@test.local` audit accounts; one real account with 8 attempts). With no signal to target, content is prioritized by **catalog coverage** (rawest skills) and by **cutting the translation-heavy ratio**.

## Impact

- Catalog translation share **67% → 61%**; MC share **23% → 28%**
- Seeded additively to prod: `added 50 exercises (store=pg)` → **623 published**
- Backend **118/118**; new-content sanity checks pass (correct option present, no dup option text, ≤3 tags, no new duplicate prompts)

Also includes a small OTEL hygiene commit (tag log records with `service_name`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)