### PR TITLE
feat(chat): SNS-style Korean conversation simulator + feedback

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -11,6 +11,7 @@ import adminRouter from './routes/admin.js';
 import exercisesRouter from './routes/exercises.js';
 import meRouter from './routes/me.js';
 import analyticsRouter from './routes/analytics.js';
+import chatRouter from './routes/chat.js';
 import { getStore } from './config/db.js';
 import { perfMiddleware } from './middleware/perf.js';
 
@@ -84,6 +85,7 @@ export function createApp() {
   app.use('/api/v1/exercises', exercisesRouter);
   app.use('/api/v1/me', meRouter);
   app.use('/api/v1/analytics', analyticsRouter);
+  app.use('/api/v1/chat', chatRouter);
 
   app.use((req, res) => res.status(404).json({ error: 'not_found', path: req.path }));
 

--- a/backend/src/controllers/chatController.js
+++ b/backend/src/controllers/chatController.js
@@ -1,0 +1,48 @@
+import * as Chat from '../services/ConversationService.js';
+
+// Error propagation handled by global error handler in app.js.
+
+export const listPersonas = async (_req, res, next) => {
+  try {
+    res.json({ personas: Chat.listPersonas() });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const start = async (req, res, next) => {
+  try {
+    const personaSlug = req.body?.personaSlug || req.body?.persona || null;
+    if (!personaSlug) {
+      const e = new Error('missing_persona'); e.status = 400; throw e;
+    }
+    res.json(await Chat.start({ userId: req.userId, personaSlug }));
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const reply = async (req, res, next) => {
+  try {
+    const { text } = req.body || {};
+    res.json(await Chat.reply({ userId: req.userId, conversationId: req.params.id, text }));
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const end = async (req, res, next) => {
+  try {
+    res.json(await Chat.end({ userId: req.userId, conversationId: req.params.id }));
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const get = async (req, res, next) => {
+  try {
+    res.json(await Chat.get({ userId: req.userId, conversationId: req.params.id }));
+  } catch (err) {
+    next(err);
+  }
+};

--- a/backend/src/db/personas.js
+++ b/backend/src/db/personas.js
@@ -1,0 +1,103 @@
+// Conversation personas for the SNS-style chat simulator. Each persona drives
+// an LLM roleplay partner: `system` shapes how it talks (register, level,
+// behaviour), `opening` is the first message the learner sees. Personas are
+// hand-authored (like modules.js) so the experience is curated and stable.
+//
+// Design rules baked into every persona's system prompt:
+// - Stay in character; this is a text chat (KakaoTalk-style), so messages are
+//   SHORT (1-2 sentences), like real texting.
+// - Write in natural Korean at a beginner (TOPIK 1) level — simple vocabulary
+//   and grammar — and keep the learner talking by asking light questions.
+// - NEVER correct the learner mid-chat. Feedback happens once, at the end, via
+//   the evaluator. Stay immersive.
+// - Respect the persona's register (반말 vs 존댓말) consistently.
+
+const SHARED_RULES = `You are a Korean conversation partner inside a language-learning app. The learner is a beginner (around TOPIK 1).
+Rules you must always follow:
+- Reply ONLY in Korean (Hangul). Do not add romanization, English, or translations.
+- Keep every message SHORT — 1 to 2 sentences, like a real text message.
+- Use simple, beginner-friendly vocabulary and grammar.
+- Stay fully in character for the scenario below. Never break character.
+- Do NOT correct the learner's Korean or act as a teacher — just chat naturally and keep the conversation going by reacting and asking light questions.
+- If the learner writes something unclear, respond naturally as a real person would (ask "응?" / "네?", or guess kindly).`;
+
+export const PERSONAS = [
+  {
+    slug: 'minji-friend',
+    name: '민지',
+    emoji: '🧃',
+    scenario: 'Close friend texting',
+    blurb: "Your close friend Minji texts you on KakaoTalk. Super casual — she speaks 반말 (informal). Great for relaxed, everyday chat.",
+    register: '반말',
+    accent: 'amber',
+    opening: '야! 뭐 해? ㅋㅋ',
+    system: `${SHARED_RULES}
+
+SCENARIO: You are 민지, the learner's close friend. You are texting on KakaoTalk.
+- Speak in 반말 (informal/casual speech). Use casual texting style and light interjections like ㅋㅋ, 응, 헐, 진짜?, 대박.
+- Be warm, playful and curious about the learner's day, food, plans, mood.`,
+  },
+  {
+    slug: 'jihun-colleague',
+    name: '지훈',
+    emoji: '👔',
+    scenario: 'Acquaintance / colleague',
+    blurb: 'Jihun is a friendly acquaintance from class or work. He speaks 존댓말 (polite) — the most useful everyday register.',
+    register: '존댓말',
+    accent: 'blue',
+    opening: '안녕하세요! 오늘 점심 드셨어요?',
+    system: `${SHARED_RULES}
+
+SCENARIO: You are 지훈, a friendly acquaintance / colleague of the learner.
+- Speak in polite 존댓말 (~요 endings). Friendly but respectful.
+- Make small talk about the day, work/study, food, weekend plans, the weather.`,
+  },
+  {
+    slug: 'cafe-staff',
+    name: '카페 직원',
+    emoji: '☕',
+    scenario: 'Café / shop situation',
+    blurb: 'A café staff member takes your order. Practice ordering, asking prices, and service-situation Korean (존댓말).',
+    register: '존댓말 (service)',
+    accent: 'green',
+    opening: '어서 오세요! 주문하시겠어요?',
+    system: `${SHARED_RULES}
+
+SCENARIO: You are a café staff member (카페 직원) serving the learner, who is a customer.
+- Speak in polite service 존댓말. Be helpful and brief.
+- Drive a realistic ordering flow: take the order, ask hot/iced, size, for-here-or-to-go, suggest items, tell the price, confirm. One step at a time.`,
+  },
+  {
+    slug: 'sua-newfriend',
+    name: '수아',
+    emoji: '🌸',
+    scenario: 'Meeting someone new',
+    blurb: 'Sua is meeting you for the first time. Polite 존댓말 first-meeting small talk: name, where you are from, hobbies.',
+    register: '존댓말',
+    accent: 'pink',
+    opening: '안녕하세요! 처음 뵙겠습니다. 이름이 뭐예요?',
+    system: `${SHARED_RULES}
+
+SCENARIO: You are 수아, meeting the learner for the very first time.
+- Speak in polite 존댓말. Be warm and a little curious, as in a first introduction.
+- Ask getting-to-know-you questions one at a time: name, where they are from, what they do, hobbies, why they study Korean.`,
+  },
+];
+
+export function getPersona(slug) {
+  return PERSONAS.find((p) => p.slug === slug) || null;
+}
+
+// Public shape — never leak the system prompt to the client.
+export function publicPersona(p) {
+  if (!p) return null;
+  return {
+    slug: p.slug,
+    name: p.name,
+    emoji: p.emoji,
+    scenario: p.scenario,
+    blurb: p.blurb,
+    register: p.register,
+    accent: p.accent,
+  };
+}

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -245,3 +245,30 @@ create index if not exists user_exercise_srs_due_idx
 alter table exercises drop constraint if exists exercises_type_check;
 alter table exercises add constraint exercises_type_check
   check (type in ('multiple_choice','translation','fill_blank'));
+
+-- ============================================================================
+-- 7. Conversation simulator (SNS-style chat practice). A conversation is a
+-- multi-turn exchange between the learner and an LLM-driven persona; at the end
+-- an evaluator stores structured semantic + syntactic feedback on the row.
+-- ============================================================================
+
+create table if not exists conversations (
+  id uuid primary key default gen_random_uuid(),
+  user_id text not null references "user"(id) on delete cascade,
+  persona_slug text not null,
+  status text not null default 'active' check (status in ('active','ended')),
+  feedback jsonb,
+  created_at timestamptz default now(),
+  ended_at timestamptz
+);
+create index if not exists conversations_user_idx on conversations(user_id, created_at desc);
+
+create table if not exists conversation_messages (
+  id uuid primary key default gen_random_uuid(),
+  conversation_id uuid not null references conversations(id) on delete cascade,
+  role text not null check (role in ('persona','learner')),
+  content text not null,
+  created_at timestamptz default now()
+);
+create index if not exists conversation_messages_conv_idx
+  on conversation_messages(conversation_id, created_at asc);

--- a/backend/src/repositories/memoryStore.js
+++ b/backend/src/repositories/memoryStore.js
@@ -11,6 +11,8 @@ const store = {
   mastery: new Map(), // key = `${user_id}::${skill}`
   srs: new Map(), // key = `${user_id}::${exercise_id}`
   lessons: new Map(),
+  conversations: new Map(), // id -> conversation row
+  conversationMessages: [], // { id, conversation_id, role, content, created_at }
 };
 
 export const memoryStore = {
@@ -26,6 +28,51 @@ export const memoryStore = {
     store.mastery.clear();
     store.srs.clear();
     store.lessons.clear();
+    store.conversations.clear();
+    store.conversationMessages.length = 0;
+  },
+
+  // conversation simulator
+  async createConversation({ user_id, persona_slug }) {
+    const id = randomUUID();
+    const row = {
+      id,
+      user_id,
+      persona_slug,
+      status: 'active',
+      feedback: null,
+      created_at: new Date().toISOString(),
+      ended_at: null,
+    };
+    store.conversations.set(id, row);
+    return row;
+  },
+  async getConversation(id) {
+    return store.conversations.get(id) || null;
+  },
+  async addConversationMessage({ conversation_id, role, content }) {
+    const row = {
+      id: randomUUID(),
+      conversation_id,
+      role,
+      content,
+      created_at: new Date().toISOString(),
+    };
+    store.conversationMessages.push(row);
+    return row;
+  },
+  async listConversationMessages(conversationId) {
+    return store.conversationMessages
+      .filter((m) => m.conversation_id === conversationId)
+      .sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+  },
+  async endConversation(id, feedback) {
+    const c = store.conversations.get(id);
+    if (!c) return null;
+    c.status = 'ended';
+    c.feedback = feedback;
+    c.ended_at = new Date().toISOString();
+    return c;
   },
 
   // user roles — application-side authorization. Keyed by Better Auth user id

--- a/backend/src/repositories/pgStore.js
+++ b/backend/src/repositories/pgStore.js
@@ -430,5 +430,33 @@ export function createPgStore({ connectionString }) {
           order by order_index asc limit 1`,
         [JSON.stringify([errorTag])]
       ),
+
+    // conversation simulator
+    createConversation: ({ user_id, persona_slug }) =>
+      one(
+        `insert into conversations (user_id, persona_slug)
+         values ($1, $2) returning *`,
+        [user_id, persona_slug]
+      ),
+    getConversation: (id) => one('select * from conversations where id = $1', [id]),
+    addConversationMessage: ({ conversation_id, role, content }) =>
+      one(
+        `insert into conversation_messages (conversation_id, role, content)
+         values ($1, $2, $3) returning *`,
+        [conversation_id, role, content]
+      ),
+    listConversationMessages: (conversationId) =>
+      all(
+        `select * from conversation_messages
+          where conversation_id = $1 order by created_at asc`,
+        [conversationId]
+      ),
+    endConversation: (id, feedback) =>
+      one(
+        `update conversations
+            set status = 'ended', feedback = $2::jsonb, ended_at = now()
+          where id = $1 returning *`,
+        [id, JSON.stringify(feedback)]
+      ),
   };
 }

--- a/backend/src/routes/chat.js
+++ b/backend/src/routes/chat.js
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { requireUser } from '../middleware/auth.js';
+import * as ctrl from '../controllers/chatController.js';
+
+const router = Router();
+router.use(requireUser);
+router.get('/personas', ctrl.listPersonas);
+router.post('/conversations', ctrl.start);
+router.post('/conversations/:id/reply', ctrl.reply);
+router.post('/conversations/:id/end', ctrl.end);
+router.get('/conversations/:id', ctrl.get);
+export default router;

--- a/backend/src/services/ConversationLLM.js
+++ b/backend/src/services/ConversationLLM.js
@@ -1,0 +1,186 @@
+// LLM layer for the conversation simulator. Two calls:
+//   personaReply()        — in-character Korean chat turn
+//   evaluateConversation()— end-of-chat structured feedback (semantic+syntactic)
+// Provider-agnostic OpenRouter chat-completions, same env contract as
+// LLMGenerator (LLM_API_KEY/OPENROUTER_API_KEY, LLM_BASE_URL, LLM_MODEL).
+
+const DEFAULT_BASE = 'https://openrouter.ai/api/v1/chat/completions';
+const DEFAULT_MODEL = 'anthropic/claude-3.5-sonnet';
+
+function clampInt(raw, fallback, min, max) {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(Math.max(Math.trunc(n), min), max);
+}
+
+// Cost brakes. Conversations are multi-turn, so each LLM roundtrip is a separate
+// call. These bound spend without being billing-grade (in-process, resets on
+// restart — a personal safety brake, like LLMGenerator's daily tally).
+const REPLY_MAX_TOKENS = clampInt(process.env.CHAT_REPLY_MAX_TOKENS, 300, 64, 2000);
+const EVAL_MAX_TOKENS = clampInt(process.env.CHAT_EVAL_MAX_TOKENS, 2000, 256, 8000);
+// Total LLM calls per UTC day across persona replies + evaluations. 0 disables.
+const DAILY_CALL_CAP = clampInt(process.env.CHAT_DAILY_CALL_CAP, 400, 0, 100000);
+
+const dailyTally = { day: null, count: 0 };
+function utcDay() {
+  return new Date().toISOString().slice(0, 10);
+}
+function reserveCall() {
+  if (!DAILY_CALL_CAP) return;
+  const today = utcDay();
+  if (dailyTally.day !== today) {
+    dailyTally.day = today;
+    dailyTally.count = 0;
+  }
+  if (dailyTally.count + 1 > DAILY_CALL_CAP) {
+    throw httpError(429, 'chat_daily_cap_reached');
+  }
+  dailyTally.count += 1;
+}
+
+async function callOpenRouter({ messages, maxTokens, temperature, json = false, fetchImpl }) {
+  const apiKey = process.env.LLM_API_KEY || process.env.OPENROUTER_API_KEY;
+  if (!apiKey) throw httpError(503, 'llm_not_configured');
+  const url = process.env.LLM_BASE_URL || DEFAULT_BASE;
+  const model = process.env.LLM_MODEL || DEFAULT_MODEL;
+
+  reserveCall();
+
+  const body = {
+    model,
+    messages,
+    temperature,
+    max_tokens: maxTokens,
+  };
+  if (json) body.response_format = { type: 'json_object' };
+
+  const res = await (fetchImpl || globalThis.fetch)(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+      'HTTP-Referer': 'https://baeu.local',
+      'X-Title': 'Baeu Learning',
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw httpError(502, `llm_error: ${res.status} ${text.slice(0, 200)}`);
+  }
+  const data = await res.json();
+  return data?.choices?.[0]?.message?.content || '';
+}
+
+// One in-character chat turn. `history` is [{role:'persona'|'learner', content}]
+// oldest-first, already including the persona's opening line.
+export async function personaReply({ persona, history, fetchImpl } = {}) {
+  if (!persona) throw httpError(400, 'persona_required');
+  const messages = [
+    { role: 'system', content: persona.system },
+    // Map our roles onto chat roles: the persona is the assistant.
+    ...history.map((m) => ({
+      role: m.role === 'persona' ? 'assistant' : 'user',
+      content: m.content,
+    })),
+  ];
+  const content = await callOpenRouter({
+    messages,
+    maxTokens: REPLY_MAX_TOKENS,
+    temperature: 0.8,
+    fetchImpl,
+  });
+  const reply = String(content).trim();
+  if (!reply) throw httpError(502, 'llm_empty_response');
+  return reply;
+}
+
+const EVAL_SYSTEM = `You are an expert Korean (한국어) tutor reviewing a short chat a beginner learner just had with a roleplay partner. Produce a structured evaluation of the LEARNER's Korean only (ignore the partner's messages except as context).
+
+Return a SINGLE valid JSON object (no markdown, no prose) with EXACTLY this shape:
+{
+  "overall": { "summary": string, "level": string, "encouragement": string },
+  "messages": [
+    {
+      "original": string,                 // the learner's message, verbatim
+      "hasIssues": boolean,
+      "corrected": string,                // the most natural Korean version (Hangul). If already good, repeat the original.
+      "issues": [
+        { "type": "particle"|"spelling"|"conjugation"|"word_order"|"word_choice"|"register"|"spacing"|"other",
+          "explanation": string }         // SHORT explanation of the fix
+      ],
+      "naturalness": string               // one short note on how natural it sounded, or "" if perfect
+    }
+  ],
+  "semantic": { "communicated": boolean, "notes": string },  // did the learner's meaning come across? did the register fit the scenario?
+  "vocab": [ { "ko": string, "en": string } ],   // up to 5 useful words/expressions from this chat to review
+  "phrases": [ { "ko": string, "en": string } ]  // up to 4 natural phrases the learner could have used
+}
+
+Guidelines:
+- "corrected" and all Korean stay in Hangul.
+- Be encouraging and concrete. Tag the SPECIFIC grammar point in each issue (e.g. "Use 을/를 for the object, not 이/가").
+- One entry in "messages" for EACH learner message, in order. Skip the partner's messages.`;
+
+// Build the evaluator request from the transcript. `locale` is the language for
+// the human-readable explanations (summary/issues/notes) — Korean text stays
+// Hangul regardless.
+export async function evaluateConversation({ persona, history, locale = 'en', fetchImpl } = {}) {
+  if (!persona) throw httpError(400, 'persona_required');
+  const transcript = history
+    .map((m) => `${m.role === 'persona' ? persona.name : 'LEARNER'}: ${m.content}`)
+    .join('\n');
+  const localeName = locale === 'pt' ? 'Portuguese' : 'English';
+  const user = `Scenario register: ${persona.register}. Partner: ${persona.name}.
+Write every human-readable explanation (summary, encouragement, issue explanations, naturalness, notes) in ${localeName}. Keep all Korean examples in Hangul.
+
+Transcript:
+${transcript}`;
+
+  const content = await callOpenRouter({
+    messages: [
+      { role: 'system', content: EVAL_SYSTEM },
+      { role: 'user', content: user },
+    ],
+    maxTokens: EVAL_MAX_TOKENS,
+    temperature: 0.3,
+    json: true,
+    fetchImpl,
+  });
+  return parseFeedback(content);
+}
+
+export function parseFeedback(raw) {
+  if (!raw) throw httpError(502, 'llm_empty_response');
+  const cleaned = String(raw).replace(/^```(?:json)?\s*/i, '').replace(/```\s*$/i, '').trim();
+  let parsed;
+  try {
+    parsed = JSON.parse(cleaned);
+  } catch {
+    const m = cleaned.match(/\{[\s\S]*\}/);
+    if (!m) throw httpError(502, 'llm_invalid_json');
+    parsed = JSON.parse(m[0]);
+  }
+  // Defensive defaults so the UI never crashes on a partial response.
+  return {
+    overall: {
+      summary: parsed?.overall?.summary || '',
+      level: parsed?.overall?.level || '',
+      encouragement: parsed?.overall?.encouragement || '',
+    },
+    messages: Array.isArray(parsed?.messages) ? parsed.messages : [],
+    semantic: {
+      communicated: Boolean(parsed?.semantic?.communicated),
+      notes: parsed?.semantic?.notes || '',
+    },
+    vocab: Array.isArray(parsed?.vocab) ? parsed.vocab.slice(0, 5) : [],
+    phrases: Array.isArray(parsed?.phrases) ? parsed.phrases.slice(0, 4) : [],
+  };
+}
+
+function httpError(status, code) {
+  const e = new Error(code);
+  e.status = status;
+  e.code = code;
+  return e;
+}

--- a/backend/src/services/ConversationLLM.js
+++ b/backend/src/services/ConversationLLM.js
@@ -4,7 +4,8 @@
 // Provider-agnostic OpenRouter chat-completions, same env contract as
 // LLMGenerator (LLM_API_KEY/OPENROUTER_API_KEY, LLM_BASE_URL, LLM_MODEL).
 
-const DEFAULT_BASE = 'https://openrouter.ai/api/v1/chat/completions';
+import { chatCompletionsUrl } from '../util/llmUrl.js';
+
 const DEFAULT_MODEL = 'anthropic/claude-3.5-sonnet';
 
 function clampInt(raw, fallback, min, max) {
@@ -41,7 +42,7 @@ function reserveCall() {
 async function callOpenRouter({ messages, maxTokens, temperature, json = false, fetchImpl }) {
   const apiKey = process.env.LLM_API_KEY || process.env.OPENROUTER_API_KEY;
   if (!apiKey) throw httpError(503, 'llm_not_configured');
-  const url = process.env.LLM_BASE_URL || DEFAULT_BASE;
+  const url = chatCompletionsUrl();
   const model = process.env.LLM_MODEL || DEFAULT_MODEL;
 
   reserveCall();

--- a/backend/src/services/ConversationService.js
+++ b/backend/src/services/ConversationService.js
@@ -1,0 +1,152 @@
+// Conversation simulator service. Orchestrates persona chat turns and the
+// end-of-chat evaluation. Ownership is enforced the same way as practice
+// sessions (assertOwner -> 403), so one user can never read or drive another's
+// conversation.
+
+import { getStore } from '../config/db.js';
+import { PERSONAS, getPersona, publicPersona } from '../db/personas.js';
+import { personaReply, evaluateConversation } from './ConversationLLM.js';
+
+// Max total messages (persona + learner) per conversation. Bounds LLM spend and
+// keeps the end-of-chat evaluation focused. Env-overridable.
+const MAX_MESSAGES = clampInt(process.env.CHAT_MAX_MESSAGES, 40, 6, 200);
+
+export function listPersonas() {
+  return PERSONAS.map(publicPersona);
+}
+
+export async function start({ userId, personaSlug }) {
+  const persona = getPersona(personaSlug);
+  if (!persona) throw httpError(404, 'persona_not_found');
+
+  const store = getStore();
+  const conversation = await store.createConversation({
+    user_id: userId,
+    persona_slug: persona.slug,
+  });
+  // Seed the chat with the persona's opening line.
+  const opening = await store.addConversationMessage({
+    conversation_id: conversation.id,
+    role: 'persona',
+    content: persona.opening,
+  });
+
+  return {
+    conversationId: conversation.id,
+    persona: publicPersona(persona),
+    messages: [publicMessage(opening)],
+  };
+}
+
+export async function reply({ userId, conversationId, text, fetchImpl }) {
+  const clean = String(text ?? '').trim();
+  if (!clean) throw httpError(400, 'empty_message');
+
+  const store = getStore();
+  const conversation = await store.getConversation(conversationId);
+  if (!conversation) throw httpError(404, 'conversation_not_found');
+  assertOwner(conversation, userId);
+  if (conversation.status !== 'active') throw httpError(409, 'conversation_ended');
+
+  const persona = getPersona(conversation.persona_slug);
+  if (!persona) throw httpError(404, 'persona_not_found');
+
+  const history = await store.listConversationMessages(conversationId);
+  if (history.length >= MAX_MESSAGES) throw httpError(409, 'conversation_full');
+
+  const learnerMsg = await store.addConversationMessage({
+    conversation_id: conversationId,
+    role: 'learner',
+    content: clean,
+  });
+
+  // Ask the persona to respond given the full history (including this message).
+  const replyText = await personaReply({
+    persona,
+    history: [...history, learnerMsg],
+    fetchImpl,
+  });
+  const personaMsg = await store.addConversationMessage({
+    conversation_id: conversationId,
+    role: 'persona',
+    content: replyText,
+  });
+
+  const count = history.length + 2;
+  return {
+    message: publicMessage(personaMsg),
+    learner: publicMessage(learnerMsg),
+    messageCount: count,
+    full: count >= MAX_MESSAGES,
+  };
+}
+
+export async function end({ userId, conversationId, fetchImpl }) {
+  const store = getStore();
+  const conversation = await store.getConversation(conversationId);
+  if (!conversation) throw httpError(404, 'conversation_not_found');
+  assertOwner(conversation, userId);
+
+  // Idempotent: a re-ended conversation returns the stored feedback.
+  if (conversation.status === 'ended' && conversation.feedback) {
+    return { feedback: normalizeFeedback(conversation.feedback), alreadyEnded: true };
+  }
+
+  const persona = getPersona(conversation.persona_slug);
+  if (!persona) throw httpError(404, 'persona_not_found');
+
+  const history = await store.listConversationMessages(conversationId);
+  const learnerTurns = history.filter((m) => m.role === 'learner').length;
+  if (learnerTurns === 0) throw httpError(400, 'nothing_to_evaluate');
+
+  const feedback = await evaluateConversation({ persona, history, locale: 'en', fetchImpl });
+  await store.endConversation(conversationId, feedback);
+  return { feedback, alreadyEnded: false };
+}
+
+export async function get({ userId, conversationId }) {
+  const store = getStore();
+  const conversation = await store.getConversation(conversationId);
+  if (!conversation) throw httpError(404, 'conversation_not_found');
+  assertOwner(conversation, userId);
+  const messages = await store.listConversationMessages(conversationId);
+  return {
+    conversationId,
+    persona: publicPersona(getPersona(conversation.persona_slug)),
+    status: conversation.status,
+    messages: messages.map(publicMessage),
+    feedback: conversation.feedback ? normalizeFeedback(conversation.feedback) : null,
+  };
+}
+
+function publicMessage(m) {
+  return { id: m.id, role: m.role, content: m.content, createdAt: m.created_at };
+}
+
+// pg returns jsonb already parsed; memory store holds the object. Guard anyway.
+function normalizeFeedback(f) {
+  if (typeof f === 'string') {
+    try { return JSON.parse(f); } catch { return null; }
+  }
+  return f;
+}
+
+function assertOwner(conversation, userId) {
+  if (userId == null) return;
+  if (String(conversation.user_id) !== String(userId)) {
+    throw httpError(403, 'conversation_forbidden');
+  }
+}
+
+function clampInt(raw, fallback, min, max) {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(Math.max(Math.trunc(n), min), max);
+}
+
+function httpError(status, code) {
+  const e = new Error(code);
+  e.status = status;
+  e.code = code;
+  return e;
+}

--- a/backend/src/services/LLMGenerator.js
+++ b/backend/src/services/LLMGenerator.js
@@ -1,7 +1,8 @@
 // LLM-backed exercise generator. Provider-agnostic; defaults to OpenRouter.
 // Output is run through AdminService.validateExercise before insertion.
 
-const DEFAULT_BASE = 'https://openrouter.ai/api/v1/chat/completions';
+import { chatCompletionsUrl } from '../util/llmUrl.js';
+
 const DEFAULT_MODEL = 'anthropic/claude-3.5-sonnet';
 
 const VALID_TYPES = ['multiple_choice', 'translation', 'fill_blank'];
@@ -94,7 +95,7 @@ export async function generateExercises({
   const apiKey = process.env.LLM_API_KEY || process.env.OPENROUTER_API_KEY;
   if (!apiKey) throw httpError(503, 'llm_not_configured');
 
-  const url = process.env.LLM_BASE_URL || DEFAULT_BASE;
+  const url = chatCompletionsUrl();
   const model = process.env.LLM_MODEL || DEFAULT_MODEL;
   const max = Math.min(Math.max(Number(count) || 10, 1), MAX_PER_REQUEST);
 

--- a/backend/src/util/llmUrl.js
+++ b/backend/src/util/llmUrl.js
@@ -1,0 +1,13 @@
+// Resolve the chat-completions endpoint from LLM_BASE_URL. The env var is
+// commonly set to the provider BASE (e.g. https://openrouter.ai/api/v1) — the
+// form most SDKs expect — but our raw fetch needs the full /chat/completions
+// path. Accept either: append the path when it's missing so a base-URL env
+// value doesn't POST to a non-JSON endpoint (which returns an HTML error page).
+const DEFAULT = 'https://openrouter.ai/api/v1/chat/completions';
+
+export function chatCompletionsUrl() {
+  const base = (process.env.LLM_BASE_URL || '').trim();
+  if (!base) return DEFAULT;
+  if (/\/chat\/completions\/?$/.test(base)) return base;
+  return `${base.replace(/\/+$/, '')}/chat/completions`;
+}

--- a/backend/tests/conversation.test.js
+++ b/backend/tests/conversation.test.js
@@ -1,0 +1,136 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { memoryStore } from '../src/repositories/memoryStore.js';
+import { resetStoreForTests } from '../src/config/db.js';
+import * as Chat from '../src/services/ConversationService.js';
+
+// A fake OpenRouter fetch: persona replies in Korean; the evaluator returns a
+// valid feedback JSON object. Switches on whether the request asks for json.
+function fakeFetch(reply = '응 좋아!', feedback = null) {
+  const fb = feedback || {
+    overall: { summary: 'Good effort', level: 'TOPIK 1', encouragement: '화이팅!' },
+    messages: [{ original: '안녕', hasIssues: false, corrected: '안녕', issues: [], naturalness: '' }],
+    semantic: { communicated: true, notes: 'Meaning was clear.' },
+    vocab: [{ ko: '안녕', en: 'hi' }],
+    phrases: [{ ko: '잘 지냈어요?', en: 'How have you been?' }],
+  };
+  return async (_url, opts) => {
+    const body = JSON.parse(opts.body);
+    const wantsJson = body.response_format?.type === 'json_object';
+    const content = wantsJson ? JSON.stringify(fb) : reply;
+    return {
+      ok: true,
+      json: async () => ({ choices: [{ message: { content } }] }),
+      text: async () => '',
+    };
+  };
+}
+
+function setup() {
+  memoryStore.reset();
+  resetStoreForTests(memoryStore);
+  process.env.OPENROUTER_API_KEY = 'test-key';
+}
+
+test('listPersonas returns the curated set with no system prompt leaked', () => {
+  setup();
+  const personas = Chat.listPersonas();
+  assert.equal(personas.length, 4);
+  for (const p of personas) {
+    assert.ok(p.slug && p.name && p.scenario);
+    assert.equal(p.system, undefined); // never leak the prompt
+  }
+});
+
+test('start creates a conversation seeded with the persona opening', async () => {
+  setup();
+  const res = await Chat.start({ userId: 'u1', personaSlug: 'minji-friend' });
+  assert.ok(res.conversationId);
+  assert.equal(res.persona.slug, 'minji-friend');
+  assert.equal(res.messages.length, 1);
+  assert.equal(res.messages[0].role, 'persona');
+  assert.ok(res.messages[0].content.length > 0);
+});
+
+test('start rejects an unknown persona', async () => {
+  setup();
+  await assert.rejects(
+    () => Chat.start({ userId: 'u1', personaSlug: 'nope' }),
+    (e) => e.status === 404 && e.code === 'persona_not_found'
+  );
+});
+
+test('reply appends learner + persona messages and calls the LLM', async () => {
+  setup();
+  const { conversationId } = await Chat.start({ userId: 'u1', personaSlug: 'minji-friend' });
+  const res = await Chat.reply({
+    userId: 'u1',
+    conversationId,
+    text: '안녕! 잘 지내?',
+    fetchImpl: fakeFetch('응 잘 지내! 너는?'),
+  });
+  assert.equal(res.learner.role, 'learner');
+  assert.equal(res.message.role, 'persona');
+  assert.equal(res.message.content, '응 잘 지내! 너는?');
+  assert.equal(res.messageCount, 3); // opening + learner + persona
+});
+
+test('reply rejects an empty message', async () => {
+  setup();
+  const { conversationId } = await Chat.start({ userId: 'u1', personaSlug: 'minji-friend' });
+  await assert.rejects(
+    () => Chat.reply({ userId: 'u1', conversationId, text: '   ', fetchImpl: fakeFetch() }),
+    (e) => e.status === 400 && e.code === 'empty_message'
+  );
+});
+
+test('IDOR: another user cannot reply to, end, or read a conversation', async () => {
+  setup();
+  const { conversationId } = await Chat.start({ userId: 'owner', personaSlug: 'minji-friend' });
+  await Chat.reply({ userId: 'owner', conversationId, text: '안녕', fetchImpl: fakeFetch() });
+
+  const forbidden = (p) => assert.rejects(p, (e) => e.status === 403 && e.code === 'conversation_forbidden');
+  await forbidden(Chat.reply({ userId: 'attacker', conversationId, text: 'hi', fetchImpl: fakeFetch() }));
+  await forbidden(Chat.end({ userId: 'attacker', conversationId, fetchImpl: fakeFetch() }));
+  await forbidden(Chat.get({ userId: 'attacker', conversationId }));
+});
+
+test('end evaluates the transcript and is idempotent', async () => {
+  setup();
+  const { conversationId } = await Chat.start({ userId: 'u1', personaSlug: 'jihun-colleague' });
+  await Chat.reply({ userId: 'u1', conversationId, text: '안녕하세요', fetchImpl: fakeFetch() });
+
+  const first = await Chat.end({ userId: 'u1', conversationId, fetchImpl: fakeFetch() });
+  assert.equal(first.alreadyEnded, false);
+  assert.equal(first.feedback.semantic.communicated, true);
+  assert.ok(Array.isArray(first.feedback.messages));
+
+  // Re-ending returns stored feedback without another LLM call (fetch would throw).
+  const again = await Chat.end({
+    userId: 'u1',
+    conversationId,
+    fetchImpl: async () => { throw new Error('should not call LLM again'); },
+  });
+  assert.equal(again.alreadyEnded, true);
+  assert.deepEqual(again.feedback.semantic, first.feedback.semantic);
+});
+
+test('end with no learner turns is rejected', async () => {
+  setup();
+  const { conversationId } = await Chat.start({ userId: 'u1', personaSlug: 'sua-newfriend' });
+  await assert.rejects(
+    () => Chat.end({ userId: 'u1', conversationId, fetchImpl: fakeFetch() }),
+    (e) => e.status === 400 && e.code === 'nothing_to_evaluate'
+  );
+});
+
+test('a conversation cannot be replied to after it ends', async () => {
+  setup();
+  const { conversationId } = await Chat.start({ userId: 'u1', personaSlug: 'minji-friend' });
+  await Chat.reply({ userId: 'u1', conversationId, text: '안녕', fetchImpl: fakeFetch() });
+  await Chat.end({ userId: 'u1', conversationId, fetchImpl: fakeFetch() });
+  await assert.rejects(
+    () => Chat.reply({ userId: 'u1', conversationId, text: '또?', fetchImpl: fakeFetch() }),
+    (e) => e.status === 409 && e.code === 'conversation_ended'
+  );
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import EndlessPractice from './pages/EndlessPractice.jsx';
+import Chat from './pages/Chat.jsx';
 import Auth from './pages/Auth.jsx';
 import Admin from './pages/Admin.jsx';
 import Progress from './pages/Progress.jsx';
@@ -20,6 +21,7 @@ function titleForPath(path) {
   if (p.startsWith('/progress')) return `Progress · ${BASE_TITLE}`;
   if (p.startsWith('/results')) return `Results · ${BASE_TITLE}`;
   if (p.startsWith('/practice')) return `Practice · ${BASE_TITLE}`;
+  if (p.startsWith('/chat')) return `Conversation · ${BASE_TITLE}`;
   if (p.startsWith('/module/')) return `Module · ${BASE_TITLE}`;
   if (p.startsWith('/lesson/')) return `Lesson · ${BASE_TITLE}`;
   if (p.startsWith('/about')) return `About · ${BASE_TITLE}`;
@@ -113,6 +115,7 @@ function Shell() {
   const isProgress = path.startsWith('/progress');
   const isResults = path.startsWith('/results');
   const isPractice = path.startsWith('/practice');
+  const isChat = path.startsWith('/chat');
   const isModule = path.startsWith('/module/');
   const isLesson = path.startsWith('/lesson/');
   const isAbout = path.startsWith('/about');
@@ -126,6 +129,7 @@ function Shell() {
     isProgress ||
     isResults ||
     isPractice ||
+    isChat ||
     isModule ||
     isLesson ||
     isAbout ||
@@ -138,11 +142,13 @@ function Shell() {
       ? 'results'
       : isProgress
       ? 'progress'
-      : isAbout
-        ? 'about'
-        : isAccount
-          ? 'account'
-          : 'practice';
+      : isChat
+        ? 'chat'
+        : isAbout
+          ? 'about'
+          : isAccount
+            ? 'account'
+            : 'practice';
 
   // Reset-password is reachable WITHOUT a session (you hit it from the email link).
   if (isResetPassword) {
@@ -170,6 +176,7 @@ function Shell() {
           isProgress,
           isResults,
           isPractice,
+          isChat,
           isModule,
           isLesson,
           isAbout,
@@ -181,7 +188,7 @@ function Shell() {
   );
 }
 
-function renderPage({ query, user, moduleSlug, lessonSlug, isAdmin, isProgress, isResults, isPractice, isModule, isLesson, isAbout, isAccount, isKnownRoute }) {
+function renderPage({ query, user, moduleSlug, lessonSlug, isAdmin, isProgress, isResults, isPractice, isChat, isModule, isLesson, isAbout, isAccount, isKnownRoute }) {
   if (isAbout) return <About />;
   if (isAdmin) return <Admin />;
   if (!isKnownRoute) return <NotFound />;
@@ -194,9 +201,11 @@ function renderPage({ query, user, moduleSlug, lessonSlug, isAdmin, isProgress, 
         ? 'your results'
         : isAccount
           ? 'your account'
-          : isLesson || isModule || isPractice
-            ? 'that practice'
-            : null;
+          : isChat
+            ? 'conversation practice'
+            : isLesson || isModule || isPractice
+              ? 'that practice'
+              : null;
     return <Auth notice={dest ? `Log in to continue to ${dest}.` : null} />;
   }
   if (isAccount) return <AccountSettings user={user} />;
@@ -205,6 +214,7 @@ function renderPage({ query, user, moduleSlug, lessonSlug, isAdmin, isProgress, 
   if (isLesson && lessonSlug) {
     return <Lesson slug={lessonSlug} returnTo={query.from || '#/'} />;
   }
+  if (isChat) return <Chat />;
   if (isPractice) {
     return (
       <EndlessPractice
@@ -345,6 +355,7 @@ function Header({ user, role, active, onLogout }) {
           {user && (
             <>
               <NavLink href="#/" active={active === 'practice'}>Practice</NavLink>
+              <NavLink href="#/chat" active={active === 'chat'}>Chat</NavLink>
               <NavLink href="#/progress" active={active === 'progress'}>Progress</NavLink>
               <NavLink href="#/results" active={active === 'results'}>Results</NavLink>
             </>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -172,6 +172,31 @@ export const api = {
   // Deep learner results (per-exercise difficulty, response-time trend, error
   // breakdown). Auth via session cookie.
   results: (days = 30) => call(`/api/v1/analytics/results?days=${days}`),
+
+  // Conversation simulator. LLM-backed turns are slow (and the backend may be
+  // cold-starting), so these use generous timeouts and no auto-retry on POST.
+  chat: {
+    personas: () => call('/api/v1/chat/personas'),
+    start: (personaSlug) =>
+      call('/api/v1/chat/conversations', {
+        method: 'POST',
+        body: JSON.stringify({ personaSlug }),
+        timeoutMs: 20_000,
+      }),
+    reply: (id, text) =>
+      call(`/api/v1/chat/conversations/${encodeURIComponent(id)}/reply`, {
+        method: 'POST',
+        body: JSON.stringify({ text }),
+        timeoutMs: 40_000,
+      }),
+    end: (id) =>
+      call(`/api/v1/chat/conversations/${encodeURIComponent(id)}/end`, {
+        method: 'POST',
+        body: '{}',
+        timeoutMs: 60_000,
+      }),
+    get: (id) => call(`/api/v1/chat/conversations/${encodeURIComponent(id)}`),
+  },
 };
 
 export const adminApi = {

--- a/frontend/src/pages/Chat.jsx
+++ b/frontend/src/pages/Chat.jsx
@@ -1,0 +1,488 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { api, ApiError } from '../api.js';
+import { useToast } from '../components/Toast.jsx';
+import { speak, hasHangul, speechSupported } from '../utils/speech.js';
+
+// SNS-style conversation simulator. Pick a persona → chat in Korean (IME) →
+// end the chat for structured semantic + syntactic feedback. LLM-backed on the
+// backend; this page only orchestrates turns.
+
+const ACCENTS = {
+  amber: 'bg-amber-100 text-amber-800 border-amber-200',
+  blue: 'bg-blue-100 text-blue-800 border-blue-200',
+  green: 'bg-green-100 text-green-800 border-green-200',
+  pink: 'bg-pink-100 text-pink-800 border-pink-200',
+};
+
+export default function Chat() {
+  const [view, setView] = useState('pick'); // 'pick' | 'chat' | 'feedback'
+  const [personas, setPersonas] = useState(null);
+  const [loadErr, setLoadErr] = useState(null);
+
+  const [persona, setPersona] = useState(null);
+  const [conversationId, setConversationId] = useState(null);
+  const [messages, setMessages] = useState([]);
+  const [starting, setStarting] = useState(false);
+
+  const [feedback, setFeedback] = useState(null);
+  const toast = useToast();
+
+  useEffect(() => {
+    let off = false;
+    api.chat
+      .personas()
+      .then((r) => { if (!off) setPersonas(r.personas || []); })
+      .catch((e) => { if (!off) setLoadErr(e.message || 'Could not load personas.'); });
+    return () => { off = true; };
+  }, []);
+
+  async function pick(p) {
+    setStarting(true);
+    try {
+      const res = await api.chat.start(p.slug);
+      setPersona(res.persona);
+      setConversationId(res.conversationId);
+      setMessages(res.messages || []);
+      setFeedback(null);
+      setView('chat');
+    } catch (e) {
+      toast.push(friendly(e), 'error');
+    } finally {
+      setStarting(false);
+    }
+  }
+
+  function reset() {
+    setView('pick');
+    setPersona(null);
+    setConversationId(null);
+    setMessages([]);
+    setFeedback(null);
+  }
+
+  if (view === 'feedback' && feedback) {
+    return <Feedback persona={persona} feedback={feedback} onRestart={reset} />;
+  }
+
+  if (view === 'chat' && persona) {
+    return (
+      <ChatRoom
+        persona={persona}
+        conversationId={conversationId}
+        messages={messages}
+        setMessages={setMessages}
+        onEnded={(fb) => { setFeedback(fb); setView('feedback'); }}
+        onBack={reset}
+      />
+    );
+  }
+
+  return (
+    <Picker personas={personas} loadErr={loadErr} starting={starting} onPick={pick} />
+  );
+}
+
+function Picker({ personas, loadErr, starting, onPick }) {
+  return (
+    <div className="max-w-3xl mx-auto">
+      <div className="mb-6">
+        <h1 className="font-heading text-2xl font-bold text-gray-900">Conversation practice</h1>
+        <p className="text-gray-600 mt-1">
+          Chat in Korean (Hangul) with a partner. When you're done, get feedback on what you
+          wrote — meaning, grammar, particles and naturalness.
+        </p>
+      </div>
+
+      {loadErr && (
+        <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg p-4 mb-4 text-sm">
+          {loadErr}
+        </div>
+      )}
+
+      {!personas && !loadErr && (
+        <div className="text-gray-500 text-sm">Loading scenarios…</div>
+      )}
+
+      <div className="grid sm:grid-cols-2 gap-4">
+        {(personas || []).map((p) => (
+          <button
+            key={p.slug}
+            type="button"
+            disabled={starting}
+            onClick={() => onPick(p)}
+            data-testid={`persona-${p.slug}`}
+            className="text-left bg-white rounded-xl shadow-card border border-gray-100 p-5 hover:border-primary-300 hover:shadow-md transition disabled:opacity-60"
+          >
+            <div className="flex items-center gap-3 mb-2">
+              <span className="text-3xl" aria-hidden>{p.emoji}</span>
+              <div>
+                <div className="font-heading font-bold text-gray-900 leading-tight">
+                  <span lang="ko">{p.name}</span>
+                </div>
+                <div className="text-xs text-gray-500">{p.scenario}</div>
+              </div>
+              <span className={`ml-auto text-xs px-2 py-0.5 rounded-full border ${ACCENTS[p.accent] || ACCENTS.blue}`}>
+                <span lang="ko">{p.register}</span>
+              </span>
+            </div>
+            <p className="text-sm text-gray-600">{p.blurb}</p>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ChatRoom({ persona, conversationId, messages, setMessages, onEnded, onBack }) {
+  const [input, setInput] = useState('');
+  const [sending, setSending] = useState(false);
+  const [ending, setEnding] = useState(false);
+  const [full, setFull] = useState(false);
+  const composing = useRef(false);
+  const endRef = useRef(null);
+  const toast = useToast();
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
+  }, [messages, sending]);
+
+  async function send() {
+    const text = input.trim();
+    if (!text || sending) return;
+    setInput('');
+    // Optimistic learner bubble.
+    const tempId = `temp-${Date.now()}`;
+    setMessages((m) => [...m, { id: tempId, role: 'learner', content: text }]);
+    setSending(true);
+    try {
+      const res = await api.chat.reply(conversationId, text);
+      setMessages((m) => [
+        ...m.filter((x) => x.id !== tempId),
+        res.learner,
+        res.message,
+      ]);
+      if (res.full) setFull(true);
+    } catch (e) {
+      // Roll back the optimistic bubble and restore the text so nothing is lost.
+      setMessages((m) => m.filter((x) => x.id !== tempId));
+      setInput(text);
+      if (e instanceof ApiError && e.code === 'conversation_full') {
+        setFull(true);
+        toast.push('This chat is full — end it to get your feedback.', 'info');
+      } else {
+        toast.push(friendly(e), 'error');
+      }
+    } finally {
+      setSending(false);
+    }
+  }
+
+  async function finish() {
+    if (ending) return;
+    const learnerTurns = messages.filter((m) => m.role === 'learner').length;
+    if (learnerTurns === 0) {
+      toast.push('Say something first, then end the chat for feedback.', 'info');
+      return;
+    }
+    setEnding(true);
+    try {
+      const res = await api.chat.end(conversationId);
+      onEnded(res.feedback);
+    } catch (e) {
+      toast.push(friendly(e), 'error');
+    } finally {
+      setEnding(false);
+    }
+  }
+
+  function onKeyDown(e) {
+    // Enter sends — but never while an IME candidate is composing (essential for
+    // Hangul input), and Shift+Enter inserts a newline.
+    if (e.key === 'Enter' && !e.shiftKey && !composing.current) {
+      e.preventDefault();
+      send();
+    }
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto flex flex-col" style={{ minHeight: '70vh' }}>
+      {/* Persona header */}
+      <div className="flex items-center gap-3 bg-white rounded-t-xl border border-gray-200 px-4 py-3">
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label="Back to scenarios"
+          className="text-gray-400 hover:text-gray-700 text-lg leading-none bg-transparent"
+        >
+          ←
+        </button>
+        <span className="text-2xl" aria-hidden>{persona.emoji}</span>
+        <div className="leading-tight">
+          <div className="font-heading font-bold text-gray-900"><span lang="ko">{persona.name}</span></div>
+          <div className="text-xs text-gray-500">{persona.scenario} · <span lang="ko">{persona.register}</span></div>
+        </div>
+        <button
+          type="button"
+          onClick={finish}
+          disabled={ending}
+          data-testid="end-chat-btn"
+          className="ml-auto text-sm font-semibold text-primary-700 bg-primary-50 hover:bg-primary-100 disabled:opacity-60 px-3 py-2 rounded-lg transition"
+        >
+          {ending ? 'Reviewing…' : 'End & get feedback'}
+        </button>
+      </div>
+
+      {/* Messages */}
+      <div
+        className="flex-1 overflow-y-auto bg-[#b2c7d9] border-x border-gray-200 px-3 py-4 space-y-3"
+        role="log"
+        aria-live="polite"
+        aria-label="Conversation"
+      >
+        {messages.map((m) => (
+          <Bubble key={m.id} message={m} persona={persona} />
+        ))}
+        {sending && <TypingBubble persona={persona} />}
+        <div ref={endRef} />
+      </div>
+
+      {/* Composer */}
+      <div className="bg-white rounded-b-xl border border-gray-200 p-3">
+        <div className="flex items-end gap-2">
+          <textarea
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={onKeyDown}
+            onCompositionStart={() => { composing.current = true; }}
+            onCompositionEnd={() => { composing.current = false; }}
+            rows={1}
+            lang="ko"
+            disabled={full}
+            data-testid="chat-input"
+            placeholder={full ? 'Chat full — end it for feedback' : '한국어로 답하세요…'}
+            className="flex-1 resize-none px-3 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none transition disabled:bg-gray-50"
+          />
+          <button
+            type="button"
+            onClick={send}
+            disabled={sending || full || !input.trim()}
+            data-testid="chat-send"
+            className="bg-primary-500 hover:bg-primary-600 disabled:opacity-50 text-white font-semibold px-4 py-2.5 rounded-lg transition"
+          >
+            Send
+          </button>
+        </div>
+        <p className="text-xs text-gray-400 mt-1.5">
+          Type in Hangul. Enter sends · Shift+Enter for a new line. Mistakes are fine — you'll see
+          corrections at the end.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function Bubble({ message, persona }) {
+  const isLearner = message.role === 'learner';
+  if (isLearner) {
+    return (
+      <div className="flex justify-end">
+        <div lang="ko" className="max-w-[80%] bg-primary-500 text-white rounded-2xl rounded-br-sm px-3.5 py-2 whitespace-pre-wrap break-words">
+          {message.content}
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="flex justify-start items-end gap-2">
+      <span className="text-xl mb-1 flex-shrink-0" aria-hidden>{persona.emoji}</span>
+      <div className="max-w-[80%]">
+        <div className="flex items-end gap-1">
+          <div lang="ko" className="bg-white text-gray-900 rounded-2xl rounded-bl-sm px-3.5 py-2 shadow-sm whitespace-pre-wrap break-words">
+            {message.content}
+          </div>
+          <SpeakButton text={message.content} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TypingBubble({ persona }) {
+  return (
+    <div className="flex justify-start items-end gap-2" aria-hidden>
+      <span className="text-xl mb-1" >{persona.emoji}</span>
+      <div className="bg-white rounded-2xl rounded-bl-sm px-4 py-3 shadow-sm">
+        <span className="inline-flex gap-1">
+          <Dot /> <Dot delay="150ms" /> <Dot delay="300ms" />
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function Dot({ delay = '0ms' }) {
+  return (
+    <span
+      className="inline-block w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce"
+      style={{ animationDelay: delay }}
+    />
+  );
+}
+
+function Feedback({ persona, feedback, onRestart }) {
+  const { overall, messages, semantic, vocab, phrases } = feedback;
+  const corrected = (messages || []).filter((m) => m.hasIssues);
+  return (
+    <div className="max-w-2xl mx-auto space-y-5">
+      <div>
+        <h1 className="font-heading text-2xl font-bold text-gray-900">Chat feedback</h1>
+        <p className="text-gray-500 text-sm mt-0.5">
+          With <span lang="ko">{persona?.name}</span> · {persona?.scenario}
+        </p>
+      </div>
+
+      {/* Overall */}
+      <div className="bg-white rounded-xl shadow-card border border-gray-100 p-5">
+        <div className="flex items-center gap-2 mb-2">
+          <span className="text-lg" aria-hidden>📝</span>
+          <h2 className="font-heading font-bold text-gray-900">Overall</h2>
+          {overall?.level && (
+            <span className="ml-auto text-xs px-2 py-0.5 rounded-full bg-primary-50 text-primary-700 border border-primary-200">
+              {overall.level}
+            </span>
+          )}
+        </div>
+        {overall?.summary && <p className="text-gray-700">{overall.summary}</p>}
+        {overall?.encouragement && (
+          <p className="text-primary-700 font-medium mt-2">{overall.encouragement}</p>
+        )}
+      </div>
+
+      {/* Semantic */}
+      <div className="bg-white rounded-xl shadow-card border border-gray-100 p-5">
+        <div className="flex items-center gap-2 mb-2">
+          <span className="text-lg" aria-hidden>{semantic?.communicated ? '✅' : '⚠️'}</span>
+          <h2 className="font-heading font-bold text-gray-900">Did your meaning come across?</h2>
+        </div>
+        <p className="text-gray-700">
+          {semantic?.communicated
+            ? 'Yes — your message was understandable.'
+            : 'Partly — some of your meaning was unclear.'}
+        </p>
+        {semantic?.notes && <p className="text-gray-600 text-sm mt-1.5">{semantic.notes}</p>}
+      </div>
+
+      {/* Per-message corrections */}
+      <div className="bg-white rounded-xl shadow-card border border-gray-100 p-5">
+        <div className="flex items-center gap-2 mb-3">
+          <span className="text-lg" aria-hidden>🔧</span>
+          <h2 className="font-heading font-bold text-gray-900">Corrections</h2>
+        </div>
+        {corrected.length === 0 ? (
+          <p className="text-gray-600 text-sm">No corrections — your Korean was clean this round. 잘했어요!</p>
+        ) : (
+          <ul className="space-y-4">
+            {corrected.map((m, i) => (
+              <li key={i} className="border-l-2 border-primary-200 pl-3">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span lang="ko" className="text-gray-400 line-through">{m.original}</span>
+                  <span className="text-gray-400">→</span>
+                  <span lang="ko" className="text-gray-900 font-semibold">{m.corrected}</span>
+                  <SpeakButton text={m.corrected} />
+                </div>
+                {Array.isArray(m.issues) && m.issues.length > 0 && (
+                  <ul className="mt-1.5 space-y-1">
+                    {m.issues.map((iss, j) => (
+                      <li key={j} className="text-sm text-gray-600 flex gap-2">
+                        <span className="text-xs px-1.5 py-0.5 rounded bg-gray-100 text-gray-600 border border-gray-200 flex-shrink-0 h-fit">
+                          {iss.type}
+                        </span>
+                        <span>{iss.explanation}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                {m.naturalness && <p className="text-xs text-gray-500 mt-1 italic">{m.naturalness}</p>}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Vocab + phrases */}
+      {(vocab?.length > 0 || phrases?.length > 0) && (
+        <div className="grid sm:grid-cols-2 gap-4">
+          {vocab?.length > 0 && (
+            <div className="bg-white rounded-xl shadow-card border border-gray-100 p-5">
+              <h2 className="font-heading font-bold text-gray-900 mb-2 text-sm uppercase tracking-wide text-gray-500">Words to review</h2>
+              <ul className="space-y-1.5">
+                {vocab.map((v, i) => (
+                  <li key={i} className="flex items-center gap-2 text-sm">
+                    <span lang="ko" className="font-semibold text-gray-900">{v.ko}</span>
+                    <SpeakButton text={v.ko} />
+                    <span className="text-gray-500">— {v.en}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {phrases?.length > 0 && (
+            <div className="bg-white rounded-xl shadow-card border border-gray-100 p-5">
+              <h2 className="font-heading font-bold text-gray-900 mb-2 text-sm uppercase tracking-wide text-gray-500">Phrases you could use</h2>
+              <ul className="space-y-1.5">
+                {phrases.map((p, i) => (
+                  <li key={i} className="flex items-center gap-2 text-sm">
+                    <span lang="ko" className="font-semibold text-gray-900">{p.ko}</span>
+                    <SpeakButton text={p.ko} />
+                    <span className="text-gray-500">— {p.en}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={onRestart}
+          className="bg-primary-500 hover:bg-primary-600 text-white font-semibold py-3 px-6 rounded-lg transition"
+        >
+          New conversation
+        </button>
+        <a
+          href="#/progress"
+          className="inline-flex items-center justify-center text-gray-600 hover:text-primary-600 font-semibold py-3 px-4 rounded-lg no-underline"
+        >
+          See progress
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function SpeakButton({ text, className = '' }) {
+  if (!hasHangul(text) || !speechSupported()) return null;
+  return (
+    <button
+      type="button"
+      onClick={(e) => { e.stopPropagation(); speak(text); }}
+      aria-label="Play Korean pronunciation"
+      title="Play pronunciation"
+      className={`inline-flex items-center justify-center w-8 h-8 text-sm rounded-full text-gray-500 hover:text-primary-600 hover:bg-primary-50 transition-colors flex-shrink-0 ${className}`}
+    >
+      <span aria-hidden>🔊</span>
+    </button>
+  );
+}
+
+function friendly(e) {
+  if (e instanceof ApiError) {
+    if (e.code === 'llm_not_configured') return 'Conversation practice needs the AI to be configured on the server.';
+    if (e.code === 'chat_daily_cap_reached') return "You've reached today's conversation limit. Try again tomorrow.";
+    if (e.kind === 'network') return e.message;
+    return e.message;
+  }
+  return e?.message || 'Something went wrong.';
+}


### PR DESCRIPTION
## What

A new way to practice: **chat in Korean (Hangul) with an LLM-driven persona, then get structured feedback** on what you wrote.

### Personas (4 SNS scenarios, hand-authored)
- 민지 — close friend, **반말** (casual KakaoTalk)
- 지훈 — acquaintance/colleague, **존댓말**
- 카페 직원 — café service situation
- 수아 — meeting someone new

### Flow
Pick persona → chat (KakaoTalk-style bubbles, TTS on persona messages, **IME-safe Enter-to-send** for Hangul) → **End & get feedback**.

### Feedback (semantic + syntactic, explanations in English)
- **Overall** summary + level estimate + encouragement
- **Semantic**: did your meaning come across? did the register fit?
- **Per-message corrections**: original → corrected, with grammar-tagged issues (particle / conjugation / word_order / word_choice / register / spelling) + short explanations + naturalness note
- **Words to review** + **phrases you could have used**

## Backend
- `db/personas.js` — curated personas; system prompt never leaked to client.
- `ConversationLLM` (OpenRouter, same env contract as LLMGenerator): `personaReply` + `evaluateConversation`. Cost brakes: per-call token caps + in-process daily call cap.
- `ConversationService` — practice-style ownership checks (`403 conversation_forbidden`), message cap, idempotent end.
- Routes under `/api/v1/chat`. `conversations` + `conversation_messages` tables (idempotent schema; **migrate already run on prod**).
- **9 new tests** (IDOR, idempotent end, caps, empty/ended guards). Backend **127/127**.

## Fix riding along
`LLM_BASE_URL` in prod is the provider base (`.../api/v1`) without `/chat/completions`, so the raw POST hit a non-JSON endpoint → HTML error. New `util/llmUrl.js` normalizes it; **`LLMGenerator` had the same latent bug** and is fixed too. Verified a live persona reply in prod returns natural Korean.

## Frontend
`Chat.jsx` page, `#/chat` route + nav link. Build green (337 modules). Existing e2e selectors are testid-based — unaffected by the new nav link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)