### PR TITLE
feat(chat): conversation errors → diagnostics, +3 personas, prod smoke

### DIFF
--- a/backend/src/db/personas.js
+++ b/backend/src/db/personas.js
@@ -82,6 +82,51 @@ SCENARIO: You are 수아, meeting the learner for the very first time.
 - Speak in polite 존댓말. Be warm and a little curious, as in a first introduction.
 - Ask getting-to-know-you questions one at a time: name, where they are from, what they do, hobbies, why they study Korean.`,
   },
+  {
+    slug: 'interviewer',
+    name: '면접관',
+    emoji: '💼',
+    scenario: 'Job interview',
+    blurb: 'A formal job interview. Practice polite, slightly formal 존댓말 and talking about yourself, experience and strengths.',
+    register: '존댓말 (formal)',
+    accent: 'purple',
+    opening: '안녕하세요, 자리에 앉으세요. 먼저 자기소개 좀 해 주시겠어요?',
+    system: `${SHARED_RULES}
+
+SCENARIO: You are 면접관, an interviewer conducting a job interview with the learner.
+- Speak in formal, polite 존댓말. Be professional and calm.
+- Ask one interview question at a time: self-introduction, experience, strengths/weaknesses, why this job, availability. React briefly before the next question.`,
+  },
+  {
+    slug: 'passerby-directions',
+    name: '행인',
+    emoji: '🧭',
+    scenario: 'Travel: asking directions',
+    blurb: 'A helpful local you stop on the street. Practice travel Korean: asking where things are, how to get there, how long it takes.',
+    register: '존댓말',
+    accent: 'teal',
+    opening: '네, 안녕하세요. 무슨 일이세요? 길을 찾고 계세요?',
+    system: `${SHARED_RULES}
+
+SCENARIO: You are a friendly local passerby (행인). The learner is a tourist asking you for help on the street.
+- Speak in polite 존댓말. Be helpful and concrete.
+- Give simple directions and answer travel questions (where the subway/bathroom/station is, how to get somewhere, how long it takes, how much). Keep landmarks simple.`,
+  },
+  {
+    slug: 'doctor-clinic',
+    name: '의사',
+    emoji: '🩺',
+    scenario: 'Doctor / clinic visit',
+    blurb: 'A doctor at a clinic. Practice describing symptoms, how long you have felt sick, and understanding simple advice — polite 존댓말.',
+    register: '존댓말',
+    accent: 'rose',
+    opening: '안녕하세요, 어디가 아프세요?',
+    system: `${SHARED_RULES}
+
+SCENARIO: You are 의사, a doctor seeing the learner as a patient at a clinic.
+- Speak in polite, caring 존댓말. Be reassuring and clear.
+- Ask one thing at a time: what hurts, since when, other symptoms (fever, cough, etc.), then give simple advice (rest, medicine, water). Keep medical vocabulary beginner-level.`,
+  },
 ];
 
 export function getPersona(slug) {

--- a/backend/src/services/ConversationDiagnostics.js
+++ b/backend/src/services/ConversationDiagnostics.js
@@ -1,0 +1,77 @@
+// Bridge conversation feedback into the existing diagnostics. When a chat is
+// evaluated, each learner message becomes a practice_attempt (correct = no
+// issues) so conversation mistakes flow into the same Progress/Results signals
+// as drills: error-tag counts, accuracy, active days, and per-skill mastery.
+//
+// The evaluator reports an issue `type`; we map it onto the established
+// error-tag taxonomy (so labels and lesson recommendations keep working) and,
+// where a concrete trackable skill exists, onto a mastery skill.
+
+import { getStore } from '../config/db.js';
+import { recordAttempt as recordMasteryAttempt } from './MasteryService.js';
+
+// issue.type -> { errorTag (always), skill (only when concrete & trackable) }
+const ISSUE_MAP = {
+  particle: { errorTag: 'particle', skill: null },
+  conjugation: { errorTag: 'verb_conjugation', skill: 'verb_conjugation' },
+  word_order: { errorTag: 'word_order', skill: 'word_order' },
+  word_choice: { errorTag: 'vocabulary', skill: null },
+  register: { errorTag: 'honorific_formality', skill: 'formality' },
+  spelling: { errorTag: 'spelling', skill: 'hangul' },
+  spacing: { errorTag: 'spacing', skill: null },
+  other: { errorTag: 'syntax', skill: null },
+};
+
+function mapIssue(type) {
+  return ISSUE_MAP[type] || ISSUE_MAP.other;
+}
+
+// Record one attempt per learner message. Best-effort by design — the caller
+// wraps this so a diagnostics hiccup never blocks returning feedback.
+export async function recordConversationDiagnostics({ userId, personaSlug, feedback }) {
+  const messages = Array.isArray(feedback?.messages) ? feedback.messages : [];
+  if (!messages.length) return { recorded: 0 };
+
+  const store = getStore();
+  const session = await store.createSession({
+    user_id: userId,
+    mode: `conversation:${personaSlug || 'chat'}`,
+  });
+
+  let recorded = 0;
+  let withIssues = 0;
+  for (const m of messages) {
+    const issues = Array.isArray(m.issues) ? m.issues : [];
+    const correct = !m.hasIssues || issues.length === 0;
+    const errorTags = correct ? [] : unique(issues.map((i) => mapIssue(i.type).errorTag));
+    const skillTags = correct ? [] : unique(issues.map((i) => mapIssue(i.type).skill).filter(Boolean));
+
+    await store.insertAttempt({
+      session_id: session.id,
+      user_id: userId,
+      exercise_id: null,
+      answer: String(m.original ?? ''),
+      correct,
+      response_ms: null,
+      error_tags: errorTags,
+      skill_tags: skillTags,
+      exercise_type: 'conversation',
+    });
+    await store.incrementSession(session.id, { correct });
+
+    // Mastery moves only on a miss with a concrete skill (we can't credit a
+    // clean message to a specific skill the evaluator didn't name).
+    if (!correct && skillTags.length) {
+      await recordMasteryAttempt({ userId, skillTags, correct: false });
+    }
+    recorded += 1;
+    if (!correct) withIssues += 1;
+  }
+  return { recorded, withIssues, sessionId: session.id };
+}
+
+function unique(arr) {
+  return [...new Set(arr)];
+}
+
+export const _internals = { ISSUE_MAP, mapIssue };

--- a/backend/src/services/ConversationService.js
+++ b/backend/src/services/ConversationService.js
@@ -6,6 +6,7 @@
 import { getStore } from '../config/db.js';
 import { PERSONAS, getPersona, publicPersona } from '../db/personas.js';
 import { personaReply, evaluateConversation } from './ConversationLLM.js';
+import { recordConversationDiagnostics } from './ConversationDiagnostics.js';
 
 // Max total messages (persona + learner) per conversation. Bounds LLM spend and
 // keeps the end-of-chat evaluation focused. Env-overridable.
@@ -101,7 +102,21 @@ export async function end({ userId, conversationId, fetchImpl }) {
 
   const feedback = await evaluateConversation({ persona, history, locale: 'en', fetchImpl });
   await store.endConversation(conversationId, feedback);
-  return { feedback, alreadyEnded: false };
+
+  // Feed the chat's mistakes into the shared diagnostics so conversation shows
+  // up in Progress/Results alongside drills. Best-effort: never block feedback.
+  let diagnostics = null;
+  try {
+    diagnostics = await recordConversationDiagnostics({
+      userId,
+      personaSlug: conversation.persona_slug,
+      feedback,
+    });
+  } catch (err) {
+    diagnostics = { recorded: 0, error: err?.code || 'diagnostics_failed' };
+  }
+
+  return { feedback, diagnostics, alreadyEnded: false };
 }
 
 export async function get({ userId, conversationId }) {

--- a/backend/tests/conversation.test.js
+++ b/backend/tests/conversation.test.js
@@ -35,7 +35,7 @@ function setup() {
 test('listPersonas returns the curated set with no system prompt leaked', () => {
   setup();
   const personas = Chat.listPersonas();
-  assert.equal(personas.length, 4);
+  assert.equal(personas.length, 7);
   for (const p of personas) {
     assert.ok(p.slug && p.name && p.scenario);
     assert.equal(p.system, undefined); // never leak the prompt
@@ -113,6 +113,48 @@ test('end evaluates the transcript and is idempotent', async () => {
   });
   assert.equal(again.alreadyEnded, true);
   assert.deepEqual(again.feedback.semantic, first.feedback.semantic);
+});
+
+test('end feeds conversation mistakes into diagnostics (attempts + mastery)', async () => {
+  setup();
+  const { conversationId } = await Chat.start({ userId: 'u1', personaSlug: 'jihun-colleague' });
+  await Chat.reply({ userId: 'u1', conversationId, text: '나는 학생이다', fetchImpl: fakeFetch() });
+
+  // Feedback with a register issue on one message → should record an attempt
+  // tagged honorific_formality and lapse the 'formality' mastery skill.
+  const feedback = {
+    overall: { summary: 's', level: 'TOPIK 1', encouragement: 'e' },
+    messages: [
+      {
+        original: '나는 학생이다',
+        hasIssues: true,
+        corrected: '저는 학생이에요',
+        issues: [{ type: 'register', explanation: 'Use polite 존댓말.' }],
+        naturalness: 'too blunt',
+      },
+    ],
+    semantic: { communicated: true, notes: '' },
+    vocab: [],
+    phrases: [],
+  };
+  const res = await Chat.end({
+    userId: 'u1',
+    conversationId,
+    fetchImpl: fakeFetch('네', feedback),
+  });
+  assert.equal(res.diagnostics.recorded, 1);
+  assert.equal(res.diagnostics.withIssues, 1);
+
+  const attempts = await memoryStore.listAttemptsForUser('u1');
+  const convAttempt = attempts.find((a) => a.exercise_type === 'conversation');
+  assert.ok(convAttempt, 'a conversation attempt was recorded');
+  assert.equal(convAttempt.correct, false);
+  assert.ok(convAttempt.error_tags.includes('honorific_formality'));
+
+  const mastery = await memoryStore.getMastery('u1', 'formality');
+  assert.ok(mastery, 'formality mastery row exists');
+  assert.equal(mastery.total_attempts, 1);
+  assert.equal(mastery.total_correct, 0);
 });
 
 test('end with no learner turns is rejected', async () => {

--- a/frontend/e2e/prod-chat-smoke.spec.js
+++ b/frontend/e2e/prod-chat-smoke.spec.js
@@ -1,0 +1,78 @@
+// Production smoke for the conversation simulator. Signs up a synthetic learner,
+// has a one-turn Korean chat with a persona (real LLM), ends it, asserts the
+// feedback view renders, then deletes the account.
+//
+// Run with:
+//   npm run e2e:prod-chat-smoke -- --workers=1
+//
+// Gated by E2E_PROD_CHAT_SMOKE=1. Writes against the real backend and spends a
+// couple of real LLM calls, so it is opt-in only.
+
+import { test, expect } from '@playwright/test';
+
+const SHOULD_RUN = process.env.E2E_PROD_CHAT_SMOKE === '1';
+test.skip(!SHOULD_RUN, 'set E2E_PROD_CHAT_SMOKE=1 to run');
+
+const BACKEND = 'https://baeu-backend-production.up.railway.app';
+
+test.afterEach(async ({ page }) => {
+  try {
+    const result = await page.evaluate(async (backend) => {
+      try {
+        const res = await fetch(`${backend}/api/auth/delete-user`, {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{}',
+        });
+        return { ok: res.ok, status: res.status };
+      } catch (e) {
+        return { ok: false, error: e?.message || String(e) };
+      }
+    }, BACKEND);
+    if (result?.ok) console.log('[prod-chat-smoke] cleanup: deleted synthetic learner');
+    else console.warn('[prod-chat-smoke] cleanup failed (non-fatal):', JSON.stringify(result));
+  } catch (e) {
+    console.warn('[prod-chat-smoke] cleanup skipped (non-fatal):', e.message);
+  }
+});
+
+test('prod: learner can chat with a persona and get feedback', async ({ page }) => {
+  const email = `audit-chat-${Date.now()}@test.local`;
+  const password = 'audit-smoke-1234';
+
+  await page.goto('/');
+  await page.getByRole('button', { name: /^sign up$/i }).click();
+  await page.locator('input[autocomplete="name"]').fill('Chat Smoke');
+  await page.locator('input[type="email"]').fill(email);
+  await page.locator('input[type="password"]').fill(password);
+  await page.locator('form').getByRole('button', { name: /^sign up$/i }).click();
+
+  await expect(
+    page.getByRole('heading', { name: /endless practice|module practice/i })
+  ).toBeVisible({ timeout: 15_000 });
+
+  // Open the conversation simulator.
+  await page.getByRole('link', { name: /^chat$/i }).click();
+  await expect(page.getByRole('heading', { name: /conversation practice/i })).toBeVisible({ timeout: 15_000 });
+
+  // Pick a persona → chat room with the opening message.
+  await page.getByTestId('persona-minji-friend').click();
+  await expect(page.getByTestId('end-chat-btn')).toBeVisible({ timeout: 20_000 });
+
+  // Send one Korean message and wait for the persona's reply (LLM round-trip).
+  await page.getByTestId('chat-input').fill('안녕! 나는 잘 지내. 너는?');
+  await page.getByTestId('chat-send').click();
+  // A persona reply is a left-aligned bubble; after our message there should be
+  // at least 2 persona bubbles (opening + reply). Give the LLM generous time.
+  await expect
+    .poll(async () => page.locator('[lang="ko"]').count(), { timeout: 45_000 })
+    .toBeGreaterThanOrEqual(3); // opening + learner + reply
+
+  // End the chat and get feedback.
+  await page.getByTestId('end-chat-btn').click();
+  await expect(page.getByRole('heading', { name: /chat feedback/i })).toBeVisible({ timeout: 60_000 });
+  await expect(page.getByRole('heading', { name: /did your meaning come across/i })).toBeVisible();
+
+  console.log(`[prod-chat-smoke] synthetic account: ${email}`);
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "e2e:prod-admin-smoke": "E2E_PROD_ADMIN_SMOKE=1 E2E_NO_WEBSERVER=1 E2E_BASE_URL=https://baeu-learning.vercel.app playwright test e2e/prod-admin-smoke.spec.js",
     "e2e:prod-idor-smoke": "E2E_PROD_IDOR_SMOKE=1 E2E_NO_WEBSERVER=1 E2E_BASE_URL=https://baeu-learning.vercel.app playwright test e2e/prod-idor-smoke.spec.js",
     "e2e:prod-lifecycle": "E2E_PROD_LIFECYCLE=1 E2E_NO_WEBSERVER=1 E2E_BASE_URL=https://baeu-learning.vercel.app playwright test e2e/prod-lifecycle-smoke.spec.js",
+    "e2e:prod-chat-smoke": "E2E_PROD_CHAT_SMOKE=1 E2E_NO_WEBSERVER=1 E2E_BASE_URL=https://baeu-learning.vercel.app playwright test e2e/prod-chat-smoke.spec.js",
     "test:e2e:audit": "npm run e2e:prod-smoke -- --workers=1"
   },
   "dependencies": {

--- a/frontend/src/pages/Chat.jsx
+++ b/frontend/src/pages/Chat.jsx
@@ -12,6 +12,9 @@ const ACCENTS = {
   blue: 'bg-blue-100 text-blue-800 border-blue-200',
   green: 'bg-green-100 text-green-800 border-green-200',
   pink: 'bg-pink-100 text-pink-800 border-pink-200',
+  purple: 'bg-purple-100 text-purple-800 border-purple-200',
+  teal: 'bg-teal-100 text-teal-800 border-teal-200',
+  rose: 'bg-rose-100 text-rose-800 border-rose-200',
 };
 
 export default function Chat() {


### PR DESCRIPTION
Follow-ups to the conversation simulator (#14), all three at once.

## 1. Conversation errors feed the diagnostics
`ConversationDiagnostics` maps each end-of-chat issue `type` onto the existing error-tag taxonomy (and a trackable mastery skill where one is concrete), then records **one `practice_attempt` per learner message** (`correct = no issues`, `exercise_type = 'conversation'`).

Result: conversation mistakes now show up in **Progress/Results** like drills — error-tag counts, accuracy, active days, and per-skill **mastery** (e.g. a register slip lapses `formality`). Best-effort: a diagnostics hiccup never blocks the feedback. `end()` returns a `diagnostics` summary.

| issue type | error tag | mastery skill |
|---|---|---|
| particle | particle | — |
| conjugation | verb_conjugation | verb_conjugation |
| word_order | word_order | word_order |
| word_choice | vocabulary | — |
| register | honorific_formality | formality |
| spelling | spelling | hangul |
| spacing | spacing | — |
| other | syntax | — |

## 2. Three more personas (7 total)
- 면접관 — job interview (formal 존댓말)
- 행인 — travel: asking directions
- 의사 — doctor / clinic visit

New accent colors added in `Chat.jsx`.

## 3. Prod chat smoke
`e2e/prod-chat-smoke.spec.js` + `npm run e2e:prod-chat-smoke`: signup → chat with a persona (real LLM round-trip) → end → assert feedback view → delete account. **Passed live against prod** (signup → reply → feedback → cleanup, 12.9s).

## Tests
Backend **128/128** (+1 diagnostics test; personas count 4→7). Frontend build green. No schema change (diagnostics reuse practice tables; personas are code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)